### PR TITLE
Resolve EPD.init argument error for Waveshare v3

### DIFF
--- a/resources/waveshare_epd/epd2in13_V3.py
+++ b/resources/waveshare_epd/epd2in13_V3.py
@@ -199,8 +199,11 @@ class EPD:
     function : Initialize the e-Paper register
     parameter:
     '''
-    def init(self):
-        if (epdconfig.module_init() != 0):
+    def init(self, update=None):
+        if update is None:
+            update = self.FULL_UPDATE
+
+        if epdconfig.module_init() != 0:
             return -1
         # EPD hardware init start
         self.reset()

--- a/shared.py
+++ b/shared.py
@@ -181,6 +181,10 @@ class SharedData:
                 logger.info("EPD type: epd2in13_V2 screen reversed")
                 self.screen_reversed = False
                 self.web_screen_reversed = False
+            elif self.config["epd_type"] == "epd2in13_V3":
+                logger.info("EPD type: epd2in13_V3 screen reversed")
+                self.screen_reversed = False
+                self.web_screen_reversed = False
             elif self.config["epd_type"] == "epd2in13_V4":
                 logger.info("EPD type: epd2in13_V4 screen reversed")
                 self.screen_reversed = True


### PR DESCRIPTION
This PR addresses the Waveshare v3 crashing loop. After applying this merge, the screen will refresh as expected. Crash logs prior listed below:
Nov 11 15:05:33 bjorn python3[9918]: TERM environment variable not set.
Nov 11 15:05:33 bjorn python3[9913]: 2024-11-11 15:05:33 - shared.py - INFO - Loading configuration...
Nov 11 15:05:35 bjorn systemd[1]: Stopping bjorn.service - Bjorn Service...
Nov 11 15:05:35 bjorn systemd[1]: bjorn.service: Deactivated successfully.
Nov 11 15:05:35 bjorn systemd[1]: Stopped bjorn.service - Bjorn Service.
Nov 11 15:05:35 bjorn systemd[1]: bjorn.service: Consumed 3.058s CPU time.
Nov 11 15:05:35 bjorn systemd[1]: Starting bjorn.service - Bjorn Service...
Nov 11 15:05:35 bjorn systemd[1]: Started bjorn.service - Bjorn Service.
Nov 11 15:05:36 bjorn python3[9986]: TERM environment variable not set.
Nov 11 15:05:36 bjorn python3[9942]: 2024-11-11 15:05:36 - shared.py - INFO - Loading configuration...
Nov 11 15:05:40 bjorn python3[9942]: 2024-11-11 15:05:39 - shared.py - INFO - Web console log file not found at
Nov 11 15:05:40 bjorn python3[9942]: /home/bjorn/Bjorn/data/logs/temp_log.txt ...
Nov 11 15:05:40 bjorn python3[9942]: 2024-11-11 15:05:40 - shared.py - INFO - Initializing the network knowledge base
Nov 11 15:05:40 bjorn python3[9942]: CSV file with headers
Nov 11 15:05:40 bjorn python3[9942]: 2024-11-11 15:05:40 - shared.py - INFO - Network knowledge base CSV file already
Nov 11 15:05:40 bjorn python3[9942]: exists at /home/bjorn/Bjorn/data/netkb.csv
Nov 11 15:05:40 bjorn python3[9942]: 2024-11-11 15:05:40 - shared.py - INFO - Initializing EPD display...
Nov 11 15:05:41 bjorn python3[9942]: 2024-11-11 15:05:41 - shared.py - INFO - EPD type: epd2in13_V3 screen reversed
Nov 11 15:05:41 bjorn python3[9942]: Error initializing EPD for full update: EPD.init() takes 1 positional argument but 2 were given
Nov 11 15:05:41 bjorn python3[9942]: 2024-11-11 15:05:41 - shared.py - ERROR - Error initializing EPD display:
Nov 11 15:05:41 bjorn python3[9942]: EPD.init() takes 1 positional argument but 2 were given
Nov 11 15:05:41 bjorn python3[9942]: Traceback (most recent call last):
Nov 11 15:05:41 bjorn python3[9942]:   File "/home/bjorn/Bjorn/Bjorn.py", line 24, in <module>
Nov 11 15:05:41 bjorn python3[9942]:     from init_shared import shared_data
Nov 11 15:05:41 bjorn python3[9942]:   File "/home/bjorn/Bjorn/init_shared.py", line 13, in <module>
Nov 11 15:05:41 bjorn python3[9942]:     shared_data = SharedData()
Nov 11 15:05:41 bjorn python3[9942]:                   ^^^^^^^^^^^^
Nov 11 15:05:41 bjorn python3[9942]:   File "/home/bjorn/Bjorn/shared.py", line 38, in __init__
Nov 11 15:05:41 bjorn python3[9942]:     self.setup_environment() # Setup the environment
Nov 11 15:05:41 bjorn python3[9942]:     ^^^^^^^^^^^^^^^^^^^^^^^^
Nov 11 15:05:41 bjorn python3[9942]:   File "/home/bjorn/Bjorn/shared.py", line 170, in setup_environment
Nov 11 15:05:41 bjorn python3[9942]:     self.initialize_epd_display()
Nov 11 15:05:41 bjorn python3[9942]:   File "/home/bjorn/Bjorn/shared.py", line 192, in initialize_epd_display
Nov 11 15:05:41 bjorn python3[9942]:     self.epd_helper.init_full_update()
Nov 11 15:05:41 bjorn python3[9942]:   File "/home/bjorn/Bjorn/epd_helper.py", line 30, in init_full_update
Nov 11 15:05:41 bjorn python3[9942]:     self.epd.init(self.epd.lut_full_update)
Nov 11 15:05:41 bjorn python3[9942]: TypeError: EPD.init() takes 1 positional argument but 2 were given
Nov 11 15:05:42 bjorn systemd[1]: bjorn.service: Main process exited, code=exited, status=1/FAILURE
Nov 11 15:05:42 bjorn systemd[1]: bjorn.service: Failed with result 'exit-code'.