### PR TITLE
Resolve 'DefaultLimitNOFILE' not properly setting in systemd

### DIFF
--- a/install_bjorn.sh
+++ b/install_bjorn.sh
@@ -255,8 +255,10 @@ root hard nofile 65535
 EOF
 
     # Configure systemd limits
-    sed -i 's/#DefaultLimitNOFILE=/DefaultLimitNOFILE=65535/' /etc/systemd/system.conf
-    sed -i 's/#DefaultLimitNOFILE=/DefaultLimitNOFILE=65535/' /etc/systemd/user.conf
+    sed -i '/^#DefaultLimitNOFILE=/d' /etc/systemd/system.conf
+    echo "DefaultLimitNOFILE=65535" >> /etc/systemd/system.conf
+    sed -i '/^#DefaultLimitNOFILE=/d' /etc/systemd/user.conf
+    echo "DefaultLimitNOFILE=65535" >> /etc/systemd/user.conf
 
     # Create /etc/security/limits.d/90-nofile.conf
     cat > /etc/security/limits.d/90-nofile.conf << EOF


### PR DESCRIPTION
Address the issue at https://github.com/infinition/Bjorn/issues/23

This limit will still be reached at some point, however, it will at least go up to `65535 FD` as expected before crashing. 

TODO: create a service to watch `ulimit -n` and restart the bjorn service when ~`65535 FD` is reached.