### PR TITLE
Restart bjorn.service automatically if file descriptor limit is reached

### DIFF
--- a/install_bjorn.sh
+++ b/install_bjorn.sh
@@ -367,6 +367,9 @@ StandardError=inherit
 Restart=always
 User=root
 
+# Check open files and restart if it reached the limit (ulimit -n buffer of 1000)
+ExecStartPost=/bin/bash -c 'FILE_LIMIT=\$(ulimit -n); THRESHOLD=\$(( FILE_LIMIT - 1000 )); while :; do TOTAL_OPEN_FILES=\$(lsof | wc -l); if [ "\$TOTAL_OPEN_FILES" -ge "\$THRESHOLD" ]; then echo "File descriptor threshold reached: \$TOTAL_OPEN_FILES (threshold: \$THRESHOLD). Restarting service."; systemctl restart bjorn.service; exit 0; fi; sleep 10; done &'
+
 [Install]
 WantedBy=multi-user.target
 EOF


### PR DESCRIPTION
This PR addresses FD lockups if the file descriptor limit is reached. Instead of needing to manually restart the service, the service will stop and restart automatically.