### PR TITLE
Fixes an issue with array based fields when saving from the web UI

### DIFF
--- a/web/scripts/config.js
+++ b/web/scripts/config.js
@@ -68,9 +68,18 @@ function generateConfigForm(config) {
     
         const formData = new FormData(formElement);
         const formDataObj = {};
-    
+        // Each of these fields contains an array of data.  Lets track these so we can ensure the format remains an array for the underlying structure.
+        const arrayFields = [
+            "portlist",
+            "mac_scan_blacklist",
+            "ip_scan_blacklist",
+            "steal_file_names",
+            "steal_file_extensions",
+        ];
+
         formData.forEach((value, key) => {
-            if (value.includes(',')) {
+            // Check if the input from the user contains a `,` character or is a known array field
+            if (value.includes(',') || arrayFields.includes(key)) {
                 formDataObj[key] = value.split(',').map(item => {
                     const trimmedItem = item.trim();
                     return isNaN(trimmedItem) ? trimmedItem : parseFloat(trimmedItem);


### PR DESCRIPTION
This PR fixes a potential issue where a user clicks "Save" from the web UI and can null out empty array fields or even change types.

In my case I had only a single `mac_scan_blacklist` value, the mac address of the Bjorn device itself.  When the UI presented this value `xx:xx:xx:xx` it did not include a `,` character and was being skipped by the check `value.includes(',')` in `config.js`.

The code know tracks known array fields and test for either including a `,` or also if its a known array field.  This will allow it to hit the same logic path and keep the data type accurate and consistent.

![image](https://github.com/user-attachments/assets/cfd1a5f9-68df-481c-b141-6b801f5818fd)

I could verify this change by grepping the `shared_config.json` and watching the "Save" turn the config into this:
```
 cat ../../config/shared_config.json | grep "blacklist"
    "blacklistcheck": true,
    "mac_scan_blacklist": "xx:xx:xx:xx:xx:d8",
    "ip_scan_blacklist": "null",
 ```

Then after the code fix 
```
cat ../../config/shared_config.json | grep "blacklist" -A3
    "blacklistcheck": true,
    "displaying_csv": true,
    "log_debug": true,
    "log_info": true,
--
    "mac_scan_blacklist": [
        "xx:xx:xx:xx:xx:d8"
    ],
    "ip_scan_blacklist": [
        "null"
    ],
    "steal_file_names": [
```