### PR TITLE
Allow customized subnet list for nmap

### DIFF
--- a/actions/scanning.py
+++ b/actions/scanning.py
@@ -42,6 +42,8 @@ class NetworkScanner:
         self.blacklistcheck = shared_data.blacklistcheck
         self.mac_scan_blacklist = shared_data.mac_scan_blacklist
         self.ip_scan_blacklist = shared_data.ip_scan_blacklist
+        self.use_custom_subnets = shared_data.use_custom_subnets
+        self.custom_subnet_list = shared_data.custom_subnet_list
         self.console = Console()
         self.lock = threading.Lock()
         self.currentdir = shared_data.currentdir
@@ -368,7 +370,11 @@ class NetworkScanner:
                     self.outer_instance.logger.error(f"Error in scan_network_and_write_to_csv (initial write): {e}")
 
             # Use nmap to scan for live hosts
-            self.outer_instance.nm.scan(hosts=str(self.network), arguments='-sn')
+            subnets = str(self.network)
+            if self.outer_instance.use_custom_subnets:
+                subnets = " ".join(self.outer_instance.custom_subnet_list)
+
+            self.outer_instance.nm.scan(hosts=subnets, arguments='-sn')
             for host in self.outer_instance.nm.all_hosts():
                 t = threading.Thread(target=self.scan_host, args=(host,))
                 t.start()

--- a/config/shared_config.json
+++ b/config/shared_config.json
@@ -97,6 +97,10 @@
     "nmap_scan_aggressivity": "-T2",
     "portstart": 1,
     "portend": 2,
+    "use_custom_subnets": false,
+    "custom_subnet_list": [
+        "192.168.1.0/24"
+    ],
     "__title_timewaits__": "Time Wait Settings",
     "timewait_smb": 0,
     "timewait_ssh": 0,

--- a/shared.py
+++ b/shared.py
@@ -156,6 +156,8 @@ class SharedData:
             "nmap_scan_aggressivity": "-T2",
             "portstart": 1,
             "portend": 2,
+            "use_custom_subnets": False,
+            "custom_subnet_list": ["192.168.1.0/24"],
             
             "__title_timewaits__": "Time Wait Settings",
             "timewait_smb": 0,

--- a/web/scripts/config.js
+++ b/web/scripts/config.js
@@ -75,6 +75,7 @@ function generateConfigForm(config) {
             "ip_scan_blacklist",
             "steal_file_names",
             "steal_file_extensions",
+            "custom_subnet_list",
         ];
 
         formData.forEach((value, key) => {


### PR DESCRIPTION
The core purpose for this change is to allow Bjorn to function in large networks; 10.0.0.0/8 subnets have millions of available addresses. This is a known limitation of nmap; nothing is well-suited to poll this many hosts.

This commit adds two new config items, boolean 'use_custom_subnets' and string[] 'custom_subnet_list'. By default, 'use_custom_subnets' is False which matches the current behavior of using the IP Interface subnet. If 'use_custom_subnets' is True, then the subnets in 'custom_subnet_list' are passed to nmap instead.