### PR TITLE
feat: add basic web authentication to Bjorn web interface

### DIFF
--- a/config/shared_config.json
+++ b/config/shared_config.json
@@ -103,5 +103,9 @@
     "timewait_telnet": 0,
     "timewait_ftp": 0,
     "timewait_sql": 0,
-    "timewait_rdp": 0
+    "timewait_rdp": 0,
+    "__title_web_auth__": "Bjorn Web Auth",
+    "web_auth_enabled": true,
+    "web_username": "admin",
+    "web_password": "changeme"
 }


### PR DESCRIPTION
- Add HTTP Basic Authentication to web panel endpoints
- Include authentication configuration options in shared_config.json
- Protect both GET and POST endpoints with credential checking

⚠️  SECURITY NOTICE: This implementation is NOT intended to be a robust or fully protected authentication solution. It provides only basic protection and has significant limitations:

• Credentials stored in plaintext configuration file • Basic authentication susceptible to interception over unencrypted connections • No brute force protection or rate limiting
• No session management or secure token handling
• Default credentials easily guessable for testing purposes

For production use, consider implementing proper authentication mechanisms such as: • HTTPS with TLS encryption
• JWT tokens or session-based authentication
• Secure credential storage (hashing, external secret management) • Rate limiting and account lockout policies
• Integration with proper identity providers