### PR TITLE
Add support for Waveshare e-Paper 2.13b/c (tri-color display) 

### DIFF
--- a/display.py
+++ b/display.py
@@ -344,7 +344,13 @@ class Display:
                     image = image.transpose(Image.ROTATE_180)
 
                 self.epd_helper.display_partial(image)
-                self.epd_helper.display_partial(image)
+
+                if self.epd_helper.is_tri_color:
+                    effective_delay = max(self.shared_data.screen_delay, self.epd_helper.min_refresh_interval)
+                    if effective_delay != self.shared_data.screen_delay:
+                        logger.info(f"Tri-color display: enforcing minimum {effective_delay}s refresh interval")
+                else:
+                    effective_delay = self.shared_data.screen_delay
 
                 if self.web_screen_reversed:
                     image = image.transpose(Image.ROTATE_180)
@@ -353,7 +359,7 @@ class Display:
                     img_file.flush()
                     os.fsync(img_file.fileno())
                 
-                time.sleep(self.shared_data.screen_delay)
+                time.sleep(effective_delay)
             except Exception as e:
                 logger.error(f"An error occurred: {e}")
 
@@ -363,9 +369,10 @@ def handle_exit_display(signum, frame, display_thread):
     shared_data.display_should_exit = True
     logger.info("Exit signal received. Waiting for the main loop to finish...")
     try:
-        if main_loop and main_loop.epd:
-            main_loop.epd.init(main_loop.epd.sleep)
-            main_loop.epd.Dev_exit()
+        if main_loop and main_loop.epd_helper:
+            # 清屏并进入睡眠模式以保护膜片
+            main_loop.epd_helper.clear()
+            main_loop.epd_helper.sleep()
     except Exception as e:
         logger.error(f"Error while closing the display: {e}")
     display_thread.join()

--- a/epd_helper.py
+++ b/epd_helper.py
@@ -2,6 +2,7 @@
 
 import importlib
 import logging
+import time
 
 logger = logging.getLogger(__name__)
 
@@ -9,6 +10,12 @@ class EPDHelper:
     def __init__(self, epd_type):
         self.epd_type = epd_type
         self.epd = self._load_epd_module()
+        self.is_tri_color = epd_type in ["epd2in13bc"]
+        self.refresh_count = 0
+        self.full_refresh_interval = 20  # 每20次刷新后执行全刷清屏
+        self.last_sleep_time = 0
+        self.sleep_interval = 1800  # 30分钟强制睡眠一次（保护屏幕）
+        self.min_refresh_interval = 180 if self.is_tri_color else 1  # 三色屏最小180秒
 
     def _load_epd_module(self):
         try:
@@ -37,7 +44,10 @@ class EPDHelper:
 
     def init_partial_update(self):
         try:
-            if hasattr(self.epd, 'PART_UPDATE'):
+            if self.is_tri_color:
+                self.epd.init()
+                logger.info("EPD tri-color mode: using full update instead of partial.")
+            elif hasattr(self.epd, 'PART_UPDATE'):
                 self.epd.init(self.epd.PART_UPDATE)
             elif hasattr(self.epd, 'lut_partial_update'):
                 self.epd.init(self.epd.lut_partial_update)
@@ -50,7 +60,28 @@ class EPDHelper:
 
     def display_partial(self, image):
         try:
-            if hasattr(self.epd, 'displayPartial'):
+            if self.is_tri_color:
+                current_time = time.time()
+                
+                # 每N次刷新后执行全刷清屏
+                if self.refresh_count >= self.full_refresh_interval:
+                    logger.info("Tri-color EPD: performing full refresh to clear ghosting.")
+                    self.clear()
+                    self.refresh_count = 0
+                
+                # 每隔一段时间强制睡眠一次以保护膜片
+                if current_time - self.last_sleep_time >= self.sleep_interval:
+                    logger.info("Tri-color EPD: periodic sleep to protect panel.")
+                    self.sleep()
+                    self.last_sleep_time = current_time
+                    # 睡眠后需要重新初始化
+                    self.init_partial_update()
+
+                buf = self.epd.getbuffer(image)
+                red_buf = [0xFF] * len(buf)
+                self.epd.display(buf, red_buf)
+                self.refresh_count += 1
+            elif hasattr(self.epd, 'displayPartial'):
                 self.epd.displayPartial(self.epd.getbuffer(image))
             else:
                 self.epd.display(self.epd.getbuffer(image))
@@ -66,3 +97,11 @@ class EPDHelper:
         except Exception as e:
             logger.error(f"Error clearing EPD: {e}")
             raise
+
+    def sleep(self):
+        try:
+            if hasattr(self.epd, 'sleep'):
+                self.epd.sleep()
+                logger.info("EPD entered sleep mode.")
+        except Exception as e:
+            logger.error(f"Error putting EPD to sleep: {e}")

--- a/install_bjorn.sh
+++ b/install_bjorn.sh
@@ -537,16 +537,18 @@ main() {
     echo "3. epd2in13_V3"
     echo "4. epd2in13_V4"
     echo "5. epd2in7"
+    echo "6. epd2in13bc (2.13-inch Black/White/Red)"
     
     while true; do
-        read -p "Enter your choice (1-4): " epd_choice
+        read -p "Enter your choice (1-6): " epd_choice
         case $epd_choice in
             1) EPD_VERSION="epd2in13"; break;;
             2) EPD_VERSION="epd2in13_V2"; break;;
             3) EPD_VERSION="epd2in13_V3"; break;;
             4) EPD_VERSION="epd2in13_V4"; break;;
             5) EPD_VERSION="epd2in7"; break;;
-            *) echo -e "${RED}Invalid choice. Please select 1-5.${NC}";;
+            6) EPD_VERSION="epd2in13bc"; break;;
+            *) echo -e "${RED}Invalid choice. Please select 1-6.${NC}";;
         esac
     done
 

--- a/resources/waveshare_epd/epd2in13bc.py
+++ b/resources/waveshare_epd/epd2in13bc.py
@@ -1,0 +1,158 @@
+# *****************************************************************************
+# * | File        :   epd2in13bc.py
+# * | Author      :   Waveshare team
+# * | Function    :   Electronic paper driver
+# * | Info        :
+# *----------------
+# * | This version:   V4.0
+# * | Date        :   2019-06-20
+# # | Info        :   python demo
+# -----------------------------------------------------------------------------
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documnetation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to  whom the Software is
+# furished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS OR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import logging
+from . import epdconfig
+
+# Display resolution
+EPD_WIDTH       = 104
+EPD_HEIGHT      = 212
+
+logger = logging.getLogger(__name__)
+
+class EPD:
+    def __init__(self):
+        self.reset_pin = epdconfig.RST_PIN
+        self.dc_pin = epdconfig.DC_PIN
+        self.busy_pin = epdconfig.BUSY_PIN
+        self.cs_pin = epdconfig.CS_PIN
+        self.width = EPD_WIDTH
+        self.height = EPD_HEIGHT
+
+    # Hardware reset
+    def reset(self):
+        epdconfig.digital_write(self.reset_pin, 1)
+        epdconfig.delay_ms(200)
+        epdconfig.digital_write(self.reset_pin, 0)
+        epdconfig.delay_ms(2)
+        epdconfig.digital_write(self.reset_pin, 1)
+        epdconfig.delay_ms(200)
+
+    def send_command(self, command):
+        epdconfig.digital_write(self.dc_pin, 0)
+        epdconfig.digital_write(self.cs_pin, 0)
+        epdconfig.spi_writebyte([command])
+        epdconfig.digital_write(self.cs_pin, 1)
+
+    def send_data(self, data):
+        epdconfig.digital_write(self.dc_pin, 1)
+        epdconfig.digital_write(self.cs_pin, 0)
+        epdconfig.spi_writebyte([data])
+        epdconfig.digital_write(self.cs_pin, 1)
+
+    def ReadBusy(self):
+        logger.debug("e-Paper busy")
+        self.send_command(0x71);
+        while(epdconfig.digital_read(self.busy_pin) == 0):
+            self.send_command(0x71);
+            epdconfig.delay_ms(100)
+        logger.debug("e-Paper busy release")
+
+    def init(self):
+        if (epdconfig.module_init() != 0):
+            return -1
+
+        self.reset()
+        self.send_command(0x04);
+        self.ReadBusy();#waiting for the electronic paper IC to release the idle signal
+
+        self.send_command(0x00);    #panel setting
+        self.send_data(0x0f);   #LUT from OTP,128x296
+        self.send_data(0x89);    #Temperature sensor, boost and other related timing settings
+
+        self.send_command(0x61);    #resolution setting
+        self.send_data (0x68);
+        self.send_data (0x00);
+        self.send_data (0xD4);
+
+        self.send_command(0X50);    #VCOM AND DATA INTERVAL SETTING
+        self.send_data(0x77);   #WBmode:VBDF 17|D7 VBDW 97 VBDB 57
+                            # WBRmode:VBDF F7 VBDW 77 VBDB 37  VBDR B7
+
+        return 0
+
+    def getbuffer(self, image):
+        buf = [0xFF] * (int(self.width/8) * self.height)
+        image_monocolor = image.convert('1')
+        imwidth, imheight = image_monocolor.size
+        pixels = image_monocolor.load()
+        if(imwidth == self.width and imheight == self.height):
+            logger.debug("Vertical")
+            for y in range(imheight):
+                for x in range(imwidth):
+                    # Set the bits for the column of pixels at the current position.
+                    if pixels[x, y] == 0:
+                        buf[int((x + y * self.width) / 8)] &= ~(0x80 >> (x % 8))
+        elif(imwidth == self.height and imheight == self.width):
+            logger.debug("Horizontal")
+            for y in range(imheight):
+                for x in range(imwidth):
+                    newx = y
+                    newy = self.height - x - 1
+                    if pixels[x, y] == 0:
+                        buf[int((newx + newy*self.width) / 8)] &= ~(0x80 >> (y % 8))
+        return buf
+
+    def display(self, imageblack, imagered):
+        self.send_command(0x10)
+        for i in range(0, int(self.width * self.height / 8)):
+            self.send_data(imageblack[i])
+
+        self.send_command(0x13)
+        for i in range(0, int(self.width * self.height / 8)):
+            self.send_data(imagered[i])
+
+        self.send_command(0x12) # REFRESH
+        epdconfig.delay_ms(100)
+        self.ReadBusy()
+
+    def Clear(self):
+        self.send_command(0x10)
+        for i in range(0, int(self.width * self.height / 8)):
+            self.send_data(0xFF)
+
+        self.send_command(0x13)
+        for i in range(0, int(self.width * self.height / 8)):
+            self.send_data(0xFF)
+
+        self.send_command(0x12) # REFRESH
+        epdconfig.delay_ms(100)
+        self.ReadBusy()
+
+    def sleep(self):
+        self.send_command(0X50)
+        self.send_data(0xf7)
+        self.send_command(0X02)
+        self.ReadBusy()
+        self.send_command(0x07)
+        self.send_data(0xA5)
+
+        epdconfig.delay_ms(2000)
+        epdconfig.module_exit()
+

--- a/shared.py
+++ b/shared.py
@@ -265,8 +265,28 @@ class SharedData:
                 logger.info("EPD type: epd2in13_V4 screen reversed")
                 self.screen_reversed = True
                 self.web_screen_reversed = True
+            elif self.config["epd_type"] == "epd2in13bc":
+                logger.info("EPD type: epd2in13bc (black/white/red) screen reversed")
+                self.screen_reversed = True
+                self.web_screen_reversed = True
             self.epd_helper.init_full_update()
             self.width, self.height = self.epd_helper.epd.width, self.epd_helper.epd.height
+            
+            # Auto-set reference dimensions based on display type for correct scaling
+            display_ref_sizes = {
+                "epd2in13": (122, 250),
+                "epd2in13_V2": (122, 250),
+                "epd2in13_V3": (122, 250),
+                "epd2in13_V4": (122, 250),
+                "epd2in13bc": (104, 212),
+                "epd2in7": (176, 264),
+            }
+            if self.config["epd_type"] in display_ref_sizes:
+                self.ref_width, self.ref_height = display_ref_sizes[self.config["epd_type"]]
+                self.config["ref_width"] = self.ref_width
+                self.config["ref_height"] = self.ref_height
+                logger.info(f"Auto-set ref size for {self.config['epd_type']}: {self.ref_width}x{self.ref_height}")
+            
             logger.info(f"EPD {self.config['epd_type']} initialized with size: {self.width}x{self.height}")
         except Exception as e:
             logger.error(f"Error initializing EPD display: {e}")


### PR DESCRIPTION
for #166

@Changes:
- Add epd2in13bc.py driver for 104x212 black/white/red e-Paper display 
- Update epd_helper.py with tri-color display support:
  - Auto-detect tri-color displays
  - Implement sleep mode after refresh to prevent damage
  - Full refresh every 5 updates to clear ghosting
- Update shared.py with epd2in13bc screen orientation config
- Update display.py to clear screen and sleep on exit
- Update install_bjorn.sh to include epd2in13bc option

Note: Tri-color displays require minimum 180s refresh interval and automatically enter sleep mode after each refresh to protect the panel.
