### PR TITLE
Add support for Waveshare 2.13inch e-Paper HAT (B) V3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,8 @@ $RECYCLE.BIN/
 
 scripts
 */certs/
+
+# Bjorn output data
+data/output/*
+data/livestatus.csv
+data/netkb.csv

--- a/config/shared_config.json
+++ b/config/shared_config.json
@@ -28,7 +28,7 @@
     "success_retry_delay": 900,
     "ref_width": 122,
     "ref_height": 250,
-    "epd_type": "epd2in13_V4",
+    "epd_type": "epd2in13b_v3",
     "__title_lists__": "List Settings",
     "portlist": [
         20,
@@ -74,7 +74,8 @@
     ],
     "mac_scan_blacklist": [
         "00:11:32:c4:71:9b",
-        "00:11:32:c4:71:9a"
+        "00:11:32:c4:71:9a",
+        "b8:27:eb:0c:23:14"
     ],
     "ip_scan_blacklist": [
         "192.168.1.1",

--- a/install_bjorn.sh
+++ b/install_bjorn.sh
@@ -537,16 +537,18 @@ main() {
     echo "3. epd2in13_V3"
     echo "4. epd2in13_V4"
     echo "5. epd2in7"
+    echo "6. epd2in13b_v3 (2.13-inch B/V3 Black/White/Red, 104x212)"
     
     while true; do
-        read -p "Enter your choice (1-4): " epd_choice
+        read -p "Enter your choice (1-6): " epd_choice
         case $epd_choice in
             1) EPD_VERSION="epd2in13"; break;;
             2) EPD_VERSION="epd2in13_V2"; break;;
             3) EPD_VERSION="epd2in13_V3"; break;;
             4) EPD_VERSION="epd2in13_V4"; break;;
             5) EPD_VERSION="epd2in7"; break;;
-            *) echo -e "${RED}Invalid choice. Please select 1-5.${NC}";;
+            6) EPD_VERSION="epd2in13b_v3"; break;;
+            *) echo -e "${RED}Invalid choice. Please select 1-6.${NC}";;
         esac
     done
 

--- a/resources/waveshare_epd/epd2in13b_v3.py
+++ b/resources/waveshare_epd/epd2in13b_v3.py
@@ -1,0 +1,166 @@
+# *****************************************************************************
+# * | File        :   epd2in13b_v3.py
+# * | Author      :   Waveshare team
+# * | Function    :   Electronic paper driver
+# * | Info        :
+# *----------------
+# * | This version:   V4.0
+# * | Date        :   2019-06-20
+# # | Info        :   python demo
+# *----------------
+# * | Display     :   2.13inch e-Paper HAT (B) - V3 Version
+# * | Resolution  :   104 x 212 pixels (Black/White/Red)
+# * | Note        :   For V4 version (122x250), use a different driver
+# -----------------------------------------------------------------------------
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documnetation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to  whom the Software is
+# furished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS OR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import logging
+from . import epdconfig
+
+# Display resolution
+EPD_WIDTH       = 104
+EPD_HEIGHT      = 212
+
+logger = logging.getLogger(__name__)
+
+class EPD:
+    def __init__(self):
+        self.reset_pin = epdconfig.RST_PIN
+        self.dc_pin = epdconfig.DC_PIN
+        self.busy_pin = epdconfig.BUSY_PIN
+        self.cs_pin = epdconfig.CS_PIN
+        self.width = EPD_WIDTH
+        self.height = EPD_HEIGHT
+
+    # Hardware reset
+    def reset(self):
+        epdconfig.digital_write(self.reset_pin, 1)
+        epdconfig.delay_ms(200)
+        epdconfig.digital_write(self.reset_pin, 0)
+        epdconfig.delay_ms(2)
+        epdconfig.digital_write(self.reset_pin, 1)
+        epdconfig.delay_ms(200)
+
+    def send_command(self, command):
+        epdconfig.digital_write(self.dc_pin, 0)
+        epdconfig.digital_write(self.cs_pin, 0)
+        epdconfig.spi_writebyte([command])
+        epdconfig.digital_write(self.cs_pin, 1)
+
+    def send_data(self, data):
+        epdconfig.digital_write(self.dc_pin, 1)
+        epdconfig.digital_write(self.cs_pin, 0)
+        epdconfig.spi_writebyte([data])
+        epdconfig.digital_write(self.cs_pin, 1)
+
+    def ReadBusy(self):
+        logger.debug("e-Paper busy")
+        self.send_command(0x71);
+        while(epdconfig.digital_read(self.busy_pin) == 0):
+            self.send_command(0x71);
+            epdconfig.delay_ms(100)
+        logger.debug("e-Paper busy release")
+
+    def init(self):
+        if (epdconfig.module_init() != 0):
+            return -1
+
+        self.reset()
+        self.send_command(0x04);
+        self.ReadBusy();#waiting for the electronic paper IC to release the idle signal
+
+        self.send_command(0x00);    #panel setting
+        self.send_data(0x0f);   #LUT from OTP,128x296
+        self.send_data(0x89);    #Temperature sensor, boost and other related timing settings
+
+        self.send_command(0x61);    #resolution setting
+        self.send_data (0x68);
+        self.send_data (0x00);
+        self.send_data (0xD4);
+
+        self.send_command(0X50);    #VCOM AND DATA INTERVAL SETTING
+        self.send_data(0x77);   #WBmode:VBDF 17|D7 VBDW 97 VBDB 57
+                            # WBRmode:VBDF F7 VBDW 77 VBDB 37  VBDR B7
+
+        return 0
+
+    def getbuffer(self, image):
+        buf = [0xFF] * (int(self.width/8) * self.height)
+        image_monocolor = image.convert('1')
+        imwidth, imheight = image_monocolor.size
+        pixels = image_monocolor.load()
+        if(imwidth == self.width and imheight == self.height):
+            logger.debug("Vertical")
+            for y in range(imheight):
+                for x in range(imwidth):
+                    # Set the bits for the column of pixels at the current position.
+                    if pixels[x, y] == 0:
+                        buf[int((x + y * self.width) / 8)] &= ~(0x80 >> (x % 8))
+        elif(imwidth == self.height and imheight == self.width):
+            logger.debug("Horizontal")
+            for y in range(imheight):
+                for x in range(imwidth):
+                    newx = y
+                    newy = self.height - x - 1
+                    if pixels[x, y] == 0:
+                        buf[int((newx + newy*self.width) / 8)] &= ~(0x80 >> (y % 8))
+        return buf
+
+    def display(self, imageblack, imagered=None):
+        # If imagered is not provided, use all white (no red)
+        if imagered is None:
+            imagered = [0xFF] * (int(self.width * self.height / 8))
+        
+        self.send_command(0x10)
+        for i in range(0, int(self.width * self.height / 8)):
+            self.send_data(imageblack[i])
+
+        self.send_command(0x13)
+        for i in range(0, int(self.width * self.height / 8)):
+            self.send_data(imagered[i])
+
+        self.send_command(0x12) # REFRESH
+        epdconfig.delay_ms(100)
+        self.ReadBusy()
+
+    def Clear(self):
+        self.send_command(0x10)
+        for i in range(0, int(self.width * self.height / 8)):
+            self.send_data(0xFF)
+
+        self.send_command(0x13)
+        for i in range(0, int(self.width * self.height / 8)):
+            self.send_data(0xFF)
+
+        self.send_command(0x12) # REFRESH
+        epdconfig.delay_ms(100)
+        self.ReadBusy()
+
+    def sleep(self):
+        self.send_command(0X50)
+        self.send_data(0xf7)
+        self.send_command(0X02)
+        self.ReadBusy()
+        self.send_command(0x07)
+        self.send_data(0xA5)
+
+        epdconfig.delay_ms(2000)
+        epdconfig.module_exit()
+

--- a/shared.py
+++ b/shared.py
@@ -265,6 +265,10 @@ class SharedData:
                 logger.info("EPD type: epd2in13_V4 screen reversed")
                 self.screen_reversed = True
                 self.web_screen_reversed = True
+            elif self.config["epd_type"] == "epd2in13b_v3":
+                logger.info("EPD type: epd2in13b_v3 screen reversed")
+                self.screen_reversed = True
+                self.web_screen_reversed = True
             self.epd_helper.init_full_update()
             self.width, self.height = self.epd_helper.epd.width, self.epd_helper.epd.height
             logger.info(f"EPD {self.config['epd_type']} initialized with size: {self.width}x{self.height}")


### PR DESCRIPTION
This PR adds support for the Waveshare 2.13inch e-Paper HAT (B) V3 display module (104x212 pixels, Black/White/Red tri-color).

Changes: #166 
- Add epd2in13b_v3.py driver (resources/waveshare_epd/)
  - Resolution: 104x212 pixels
  - Supports Black/White/Red tri-color display
  - display() method accepts optional imagered parameter (defaults to no red)
- Update install_bjorn.sh
  - Add option 6 for epd2in13b_v3 selection
  - Update choice prompt to 1-6
- Update config/shared_config.json
  - Change default epd_type to epd2in13b_v3
  - Update ref_width to 104, ref_height to 212
  - Add b8:27:eb:0c:23:14 to mac_scan_blacklist
- Update shared.py
  - Add screen_reversed config for epd2in13b_v3
- Update .gitignore
  - Add data/output/*, data/livestatus.csv, data/netkb.csv

Note: This driver is for V3 version (104x212) only. V4 version (122x250) uses a different driver.