### PR TITLE
Fix Python 3.13 compatibility (cgi and telnetlib removal with except for previous python versions)

### DIFF
--- a/actions/steal_files_telnet.py
+++ b/actions/steal_files_telnet.py
@@ -3,7 +3,10 @@ steal_files_telnet.py - This script connects to remote Telnet servers using prov
 """
 
 import os
-import telnetlib
+try:
+    import telnetlib
+except ImportError:
+    import telnetlib3 as telnetlib
 import logging
 import time
 from rich.console import Console

--- a/actions/telnet_connector.py
+++ b/actions/telnet_connector.py
@@ -5,7 +5,10 @@ and logs the successful login attempts.
 
 import os
 import pandas as pd
-import telnetlib
+try:
+    import telnetlib
+except ImportError:
+    import telnetlib3 as telnetlib
 import threading
 import logging
 import time

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -198,7 +198,7 @@ class Orchestrator:
             row[action_key] = ""
 
         # Check if the action is already successful and if retries are disabled for successful actions
-        if 'success' in row[action_key]:
+        if action_key in row and 'success' in row[action_key]:
             if not self.shared_data.retry_success_actions:
                 return False
             else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,5 @@ pysmb==1.2.10
 pymysql==1.1.1
 sqlalchemy==2.0.36
 python-nmap==0.7.1
+legacy-cgi
+telnetlib3

--- a/utils.py
+++ b/utils.py
@@ -7,7 +7,10 @@ import json
 import csv
 import zipfile
 import uuid
-import cgi
+try:
+    import legacy_cgi as cgi
+except ImportError:
+    import cgi
 import io
 import importlib
 import logging


### PR DESCRIPTION
Python 3.13 removed several deprecated standard library modules such as cgi and telnetlib.

This patch restores compatibility by:

- replacing cgi with legacy-cgi
- replacing telnetlib with telnetlib3
- adding required dependencies to requirements.txt

Tested on:
Raspberry Pi Zero W
Raspberry Pi OS (Debian 13)
Python 3.13