### PR TITLE
feat: stabilize runtime lifecycle and add optional web authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,4 @@ $RECYCLE.BIN/
 
 scripts
 */certs/
+config/web_auth.json

--- a/Bjorn.py
+++ b/Bjorn.py
@@ -22,13 +22,15 @@ import time
 import sys
 import subprocess
 from init_shared import shared_data
-from display import Display, handle_exit_display
+from display import Display
 from comment import Commentaireia
-from webapp import web_thread, handle_exit_web
+from webapp import web_thread
 from orchestrator import Orchestrator
 from logger import Logger
 
 logger = Logger(name="Bjorn.py", level=logging.DEBUG)
+SHUTDOWN_TIMEOUT_SECONDS = 75
+RESIDUAL_THREAD_GRACE_SECONDS = 5
 
 class Bjorn:
     """Main class for Bjorn. Manages the primary operations of the application."""
@@ -72,7 +74,10 @@ class Bjorn:
                 self.shared_data.orchestrator_should_exit = False
                 self.shared_data.manual_mode = False
                 self.orchestrator = Orchestrator()
-                self.orchestrator_thread = threading.Thread(target=self.orchestrator.run)
+                self.orchestrator_thread = threading.Thread(
+                    target=self.orchestrator.run,
+                    name="BjornOrchestrator",
+                )
                 self.orchestrator_thread.start()
                 logger.info("Orchestrator thread started, automatic mode activated.")
             else:
@@ -106,25 +111,158 @@ class Bjorn:
     def start_display():
         """Start the display thread"""
         display = Display(shared_data)
-        display_thread = threading.Thread(target=display.run)
+        display_thread = threading.Thread(
+            target=display.run,
+            name="BjornDisplay",
+        )
         display_thread.start()
-        return display_thread
+        return display, display_thread
 
-def handle_exit(sig, frame, display_thread, bjorn_thread, web_thread):
-    """Handles the termination of the main, display, and web threads."""
+
+def request_shutdown(display):
+    """Set every component's exit flag and wake sleeping display workers."""
     shared_data.should_exit = True
-    shared_data.orchestrator_should_exit = True  # Ensure orchestrator stops
-    shared_data.display_should_exit = True  # Ensure display stops
-    shared_data.webapp_should_exit = True  # Ensure web server stops
-    handle_exit_display(sig, frame, display_thread)
-    if display_thread.is_alive():
-        display_thread.join()
-    if bjorn_thread.is_alive():
-        bjorn_thread.join()
-    if web_thread.is_alive():
-        web_thread.join()
+    shared_data.orchestrator_should_exit = True
+    shared_data.display_should_exit = True
+    shared_data.webapp_should_exit = True
+    display.request_stop()
+
+
+def wait_for_shutdown_threads(threads, timeout=SHUTDOWN_TIMEOUT_SECONDS):
+    """Wait for application threads and return names that missed the deadline."""
+    deadline = time.monotonic() + timeout
+    unique_threads = []
+    seen_threads = set()
+    current_thread = threading.current_thread()
+
+    for thread in threads:
+        if thread is None or thread is current_thread:
+            continue
+        thread_identity = id(thread)
+        if thread_identity in seen_threads:
+            continue
+        seen_threads.add(thread_identity)
+        unique_threads.append(thread)
+
+    while True:
+        alive_threads = [
+            thread for thread in unique_threads if thread.is_alive()
+        ]
+        if not alive_threads:
+            return []
+
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return [
+                getattr(thread, "name", repr(thread))
+                for thread in alive_threads
+            ]
+
+        join_slice = min(0.25, remaining)
+        for thread in alive_threads:
+            try:
+                thread.join(timeout=join_slice)
+            except Exception as error:
+                thread_name = getattr(thread, "name", repr(thread))
+                logger.error(
+                    f"Unable to join thread {thread_name}: "
+                    f"{type(error).__name__}: {error}"
+                )
+                return [thread_name]
+
+
+def describe_thread(thread):
+    """Return bounded diagnostics for a Python thread left during shutdown."""
+    target = getattr(thread, "_target", None)
+    if target is None:
+        target_name = "none"
+    else:
+        target_module = getattr(target, "__module__", type(target).__module__)
+        target_qualname = getattr(
+            target,
+            "__qualname__",
+            type(target).__qualname__,
+        )
+        target_name = f"{target_module}.{target_qualname}"
+
+    thread_class = (
+        f"{type(thread).__module__}.{type(thread).__qualname__}"
+    )
+    return (
+        f"name={getattr(thread, 'name', 'unknown')} "
+        f"class={thread_class} "
+        f"target={target_name} "
+        f"daemon={getattr(thread, 'daemon', 'unknown')}"
+    )
+
+
+def remaining_python_threads():
+    """Return live Python threads other than the signal-handling thread."""
+    current_thread = threading.current_thread()
+    return [
+        thread
+        for thread in threading.enumerate()
+        if thread is not current_thread and thread.is_alive()
+    ]
+
+
+def handle_exit(
+    sig,
+    frame,
+    display,
+    display_thread,
+    bjorn,
+    bjorn_thread,
+    web_thread,
+):
+    """Request shutdown and wait for all application-owned threads."""
+    del sig, frame
+    request_shutdown(display)
+    shutdown_threads = [
+        display_thread,
+        *display.background_threads(),
+        bjorn_thread,
+        bjorn.orchestrator_thread,
+        web_thread,
+    ]
+    alive_thread_names = wait_for_shutdown_threads(shutdown_threads)
+    if alive_thread_names:
+        logger.error(
+            "Shutdown deadline exceeded; threads still running: "
+            + ", ".join(alive_thread_names)
+        )
+        raise SystemExit(1)
+
+    display.close_hardware()
+
+    residual_threads = remaining_python_threads()
+    if residual_threads:
+        logger.warning(
+            "Waiting for residual Python threads: "
+            + "; ".join(
+                describe_thread(thread)
+                for thread in residual_threads
+            )
+        )
+        residual_thread_names = wait_for_shutdown_threads(
+            residual_threads,
+            timeout=RESIDUAL_THREAD_GRACE_SECONDS,
+        )
+        if residual_thread_names:
+            logger.error(
+                "Residual Python thread deadline exceeded: "
+                + ", ".join(residual_thread_names)
+            )
+            raise SystemExit(1)
+
     logger.info("Main loop finished. Clean exit.")
-    sys.exit(0)  # Used sys.exit(0) instead of exit(0)
+    raise SystemExit(0)
+
+
+def wait_for_primary_thread(primary_thread):
+    """Keep the interpreter active while Bjorn's primary thread is running."""
+    while primary_thread.is_alive():
+        primary_thread.join(timeout=1)
 
 
 
@@ -137,22 +275,51 @@ if __name__ == "__main__":
 
         logger.info("Starting display thread...")
         shared_data.display_should_exit = False  # Initialize display should_exit
-        display_thread = Bjorn.start_display()
+        display, display_thread = Bjorn.start_display()
 
         logger.info("Starting Bjorn thread...")
         bjorn = Bjorn(shared_data)
         shared_data.bjorn_instance = bjorn  # Assigner l'instance de Bjorn à shared_data
-        bjorn_thread = threading.Thread(target=bjorn.run)
+        bjorn_thread = threading.Thread(
+            target=bjorn.run,
+            name="BjornMain",
+        )
         bjorn_thread.start()
 
         if shared_data.config["websrv"]:
             logger.info("Starting the web server...")
             web_thread.start()
 
-        signal.signal(signal.SIGINT, lambda sig, frame: handle_exit(sig, frame, display_thread, bjorn_thread, web_thread))
-        signal.signal(signal.SIGTERM, lambda sig, frame: handle_exit(sig, frame, display_thread, bjorn_thread, web_thread))
+        signal.signal(
+            signal.SIGINT,
+            lambda sig, frame: handle_exit(
+                sig,
+                frame,
+                display,
+                display_thread,
+                bjorn,
+                bjorn_thread,
+                web_thread,
+            ),
+        )
+        signal.signal(
+            signal.SIGTERM,
+            lambda sig, frame: handle_exit(
+                sig,
+                frame,
+                display,
+                display_thread,
+                bjorn,
+                bjorn_thread,
+                web_thread,
+            ),
+        )
+        wait_for_primary_thread(bjorn_thread)
 
     except Exception as e:
         logger.error(f"An exception occurred during thread start: {e}")
-        handle_exit_display(signal.SIGINT, None)
-        exit(1)
+        shared_data.should_exit = True
+        shared_data.orchestrator_should_exit = True
+        shared_data.display_should_exit = True
+        shared_data.webapp_should_exit = True
+        raise SystemExit(1) from e

--- a/Bjorn.py
+++ b/Bjorn.py
@@ -158,8 +158,12 @@ def wait_for_shutdown_threads(threads, timeout=SHUTDOWN_TIMEOUT_SECONDS):
                 for thread in alive_threads
             ]
 
-        join_slice = min(0.25, remaining)
-        for thread in alive_threads:
+        for index, thread in enumerate(alive_threads):
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            threads_remaining = len(alive_threads) - index
+            join_slice = min(0.25, remaining / threads_remaining)
             try:
                 thread.join(timeout=join_slice)
             except Exception as error:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -303,6 +303,76 @@ Defines various settings for Bjorn, including:
 - Port lists and blacklists.
 These settings are accessible on the webpage.
 
+### Optional Web Authentication
+
+`web_auth.py` implements opt-in HTTP Basic authentication using a salted scrypt
+password verifier. Credentials are managed by `configure_web_auth.py` and kept
+out of `shared_config.json`, the web configuration endpoint, and Git.
+
+When no credential file exists, current unauthenticated behavior is preserved.
+When credentials exist and are enabled, every GET, HEAD, POST, static asset,
+and API route requires authentication. An existing but unreadable credential
+file fails closed.
+
+An HTTP Basic challenge without an Authorization header is an expected part of
+browser authentication and still receives `401`, but it is not recorded as an
+invalid-credential warning. Requests that supply a malformed or incorrect
+Authorization header are logged with the method, normalized path, and source
+address. Query parameters are omitted from that audit message.
+
+Rejected entity-bearing requests never wait for a declared request body before
+returning the authentication challenge. Bytes that are already available are
+drained non-blockingly, then the server returns `401` with `Connection: close`.
+This prevents an incomplete unauthenticated POST from monopolizing Bjorn's
+single-request web server.
+
+`install_stability_web_auth.sh` provides one transactional deployment path for
+the complete scanner, lifecycle, hardware-shutdown, web-server, and optional
+authentication change set. These areas share the web-server lifecycle and are
+therefore installed and rolled back atomically instead of being stacked as
+independent patches. The installer validates the source and credential files,
+snapshots every managed target file, stops and restarts the systemd service
+once, verifies that the new service remains active and serves HTTP on port
+8000, and restores the complete snapshot automatically on failure. The web
+server enables address reuse so a quick service restart does not make it drift
+to port 8001. Successful deployment snapshots can also be selected explicitly
+with `install_stability_web_auth.sh --restore`. A restore creates its own
+recovery snapshot before changing files, so it can be reversed as well.
+It also installs `/usr/local/sbin/http_auth` as the short management command;
+the main installer offers that command and credential configuration as two
+separate opt-in choices during a dedicated full-install step.
+`install_bjorn.sh --show-plan` renders that integrated nine-step sequence
+without creating logs, requiring root, or changing the system.
+Credential validation failures remain inside the credential prompt so a retry
+actually reruns the failed operation. Other required-step failures abort the
+installer immediately. The installer starts `bjorn.service` itself and its
+final verification requires both an active unit and HTTP `200` or `401` on port
+8000, preventing warning-only or false-success fresh installations.
+For automation, `http_auth set USER --password-stdin` reads one password line
+from standard input so the plaintext is not placed in a command argument or
+shell history.
+
+Targeted web-authentication checks remain available for development:
+
+```bash
+# Syntax, compile, and isolated HTTP/unit tests
+./tests/run_web_auth_validation.sh --unit
+
+# Live command and HTTP checks with automatic credential restoration
+sudo ./tests/run_web_auth_validation.sh --runtime \
+  --target /home/bjorn/Bjorn
+
+# Both levels
+sudo ./tests/run_web_auth_validation.sh --all \
+  --target /home/bjorn/Bjorn
+```
+
+The runtime test temporarily installs a generated verifier, exercises `set`,
+`status`, `disable`, and `enable`, validates correct, incorrect, missing, and
+private-file requests, checks the incomplete-POST regression and challenge
+stress behavior, then restores the original credential file even on failure or
+interruption. Release validation uses the combined runner documented below.
+
 ### 🛠️ Actions Configuration (`actions.json`)
 
 Lists the actions to be performed by Bjorn, including (dynamically generated with the content of the folder):
@@ -340,6 +410,106 @@ In my journey to make Bjorn work with the different screen versions, I struggled
 2. Use an isolated network.
 3. Follow ethical guidelines.
 4. Document test cases.
+
+### Stability and web-authentication validation
+
+The combined contribution has two validation levels:
+
+```bash
+# Fast, non-invasive syntax, compile, unit, and integration checks
+./tests/run_stability_web_auth_validation.sh --unit
+
+# Live Raspberry Pi checks, including scanner completion, authentication,
+# credential restoration, and a real service stop/start
+sudo ./tests/run_stability_web_auth_validation.sh --runtime \
+  --target /home/bjorn/Bjorn
+
+# Both levels in the required order
+sudo ./tests/run_stability_web_auth_validation.sh --all \
+  --target /home/bjorn/Bjorn
+
+# Optional longer observation before a release or pull request
+sudo ./tests/run_stability_web_auth_validation.sh --all \
+  --target /home/bjorn/Bjorn \
+  --duration 90
+```
+
+The combined runner prints a compact, color-coded release summary by default
+and shows complete underlying diagnostics automatically when a check fails.
+Use `--verbose` to show every test name and internal validation marker, or set
+`NO_COLOR=1` when plain output is required for a log collector.
+
+The unit level also runs `tests/run_fresh_installer_integration.sh`. It sources
+the real fresh installer with all destination paths redirected into a temporary
+root, then exercises declining the optional tool, installing it without
+credentials, configuring a real salted test verifier through the installed
+command, checking mode `0600`, and using status/disable/enable. Linux requires
+the management command to be a real symbolic link. The temporary root is
+removed automatically and no live Bjorn file or system command path changes.
+
+The runtime level verifies that every installed runtime file matches the tested
+checkout. The service PID and authenticated web response must remain stable,
+thread use must stay below a configurable limit, a scan must complete without
+executor errors, shutdown must be clean and bounded, and the service must
+return on port 8000. It then exercises the web-authentication command and HTTP
+contract and restores the original credential state. The default runtime
+observation is 30 seconds; use `--duration 90` for the longer
+release-validation profile.
+When a freshly started scan needs longer than the observation window, the
+runner continues monitoring only until that scan completes, bounded by
+`--scan-timeout` (90 seconds by default).
+
+If systemd stops Bjorn while Nmap is producing its XML result, the resulting
+interruption is logged as an expected shutdown event. The same exception
+outside an active shutdown remains a scanner error.
+
+The scanner also disables Rich's automatic progress refresh thread. Progress
+updates remain visible, but run synchronously in the orchestrator-owned scan
+thread so a daemon refresh cannot write to the terminal during interpreter
+shutdown.
+
+After all Bjorn-owned workers have stopped, the lifecycle handler gives any
+remaining Python library thread a bounded grace period. Residual threads are
+reported with their name, class, target, and daemon state. A thread that misses
+the grace deadline makes shutdown fail explicitly instead of allowing a false
+`Clean exit` followed by an interpreter-shutdown traceback.
+
+Display shutdown also puts the e-paper panel to sleep, closes every gpiozero
+device created by the Waveshare backend, and closes the shared pin factory.
+This stops gpiozero's hold worker and lgpio's callback thread before Python
+finalization.
+
+The Python lgpio binding starts one module-global notification daemon. Closing
+the gpiochip alone does not stop its blocking pipe read, so final hardware
+shutdown explicitly stops that worker, closes its notification handle to wake
+the read, and joins it with a bounded timeout.
+
+Host discovery is also shutdown-aware. `python-nmap` normally waits
+indefinitely in `Popen.communicate()`, which can make `systemctl stop` wait for
+an entire `/24` discovery pass. Bjorn now launches the equivalent Nmap XML
+command with short polling intervals. A normal scan is never shortened; only
+an active application shutdown terminates the child process. Completed output
+continues through python-nmap's existing XML parser.
+
+The scanner/lifecycle and authentication changes intentionally share one
+`webapp.py`. A single installer and rollback snapshot prevent order-dependent
+layering and ensure that the exact code covered by the combined validation
+suite is the code running on the device.
+
+For release validation on a freshly installed card, capture the pre-reboot
+state and verify it after a real reboot with:
+
+```bash
+sudo ./tests/run_reboot_persistence_validation.sh --prepare
+sudo reboot
+# Reconnect after boot, then:
+sudo ./tests/run_reboot_persistence_validation.sh --verify
+```
+
+The hand-off file contains only the old boot ID, expected HTTP result, a hash of
+the credential file, and the management-command target. Verification requires a
+new boot ID, the same access-control state, a completed scan, bounded thread
+use, and a clean current-boot journal.
 
 ## 💻 Web Interface
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -446,6 +446,8 @@ credentials, configuring a real salted test verifier through the installed
 command, checking mode `0600`, and using status/disable/enable. Linux requires
 the management command to be a real symbolic link. The temporary root is
 removed automatically and no live Bjorn file or system command path changes.
+The canonical runner requires pandas so the real CSV type-inference regression
+tests cannot be silently skipped.
 
 The runtime level verifies that every installed runtime file matches the tested
 checkout. The service PID and authenticated web response must remain stable,
@@ -467,6 +469,13 @@ The scanner also disables Rich's automatic progress refresh thread. Progress
 updates remain visible, but run synchronously in the orchestrator-owned scan
 thread so a daemon refresh cannot write to the terminal during interpreter
 shutdown.
+
+Live-status aggregation treats the semicolon-separated `Ports` column as text
+at the CSV boundary. This prevents a single numeric port plus empty cells from
+being inferred as floats by pandas. Empty port tokens are ignored, and a
+failed aggregation stops without writing partial counters or logging a false
+success. The live runtime validation rejects both aggregation and result-write
+errors.
 
 After all Bjorn-owned workers have stopped, the lifecycle handler gives any
 remaining Python library thread a bounded grace period. Residual threads are

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -139,6 +139,128 @@ Change the value according to your screen model:
 Press Esc to exit insert mode
 Type :wq and press Enter to save and quit
 
+##### 3.2: Stability Upgrade and Optional Web Authentication
+
+The current source includes bounded scan workers, deterministic process and
+hardware shutdown, and optional web authentication. Fresh installations receive
+these files through the normal installer. The full installation now adds an
+optional web-authentication step, bringing the sequence to nine steps. It first
+asks whether the `http_auth` management tool should be installed at all. Only
+after consent does it offer to configure a username and securely read the
+password without writing it to the installer log or shell history.
+If credential validation fails, the credential prompt is repeated locally;
+the installer never advances to file ownership or service setup without a
+credential file. Required installation failures stop the run instead of
+offering a generic retry that cannot replay the failed command. The final step
+starts `bjorn.service` and reports success only after the service is active and
+the web interface returns HTTP `200` or `401` on port 8000.
+
+The integrated full-install sequence can be reviewed without root privileges or
+system changes:
+
+```bash
+./install_bjorn.sh --show-plan
+```
+
+The actual optional-tool choices and credential lifecycle can be tested without
+touching a live installation:
+
+```bash
+./tests/run_fresh_installer_integration.sh
+```
+
+This creates and removes a temporary test root automatically.
+
+Use the transactional installer to upgrade an existing Bjorn installation. It
+deploys the complete stability and authentication feature set as one unit,
+creates one rollback snapshot, stops and starts the service once, and verifies
+the service and web interface before reporting success:
+
+```bash
+cd /path/to/the/updated/Bjorn-checkout
+sudo ./install_stability_web_auth.sh \
+  --target /home/bjorn/Bjorn \
+  --username bjornadmin
+```
+
+The password prompt does not place the password in shell history. Omitting both
+`--username` and `--credentials` installs the stability changes while leaving
+the web interface open for backwards compatibility:
+
+```bash
+sudo ./install_stability_web_auth.sh --target /home/bjorn/Bjorn
+```
+
+An existing valid credential file can be reused instead:
+
+```bash
+sudo ./install_stability_web_auth.sh \
+  --target /home/bjorn/Bjorn \
+  --credentials /path/to/web_auth.json
+```
+
+If validation, deployment, or startup fails, the installer restores the entire
+previous file set and starts the previous version again. Every successful
+installation prints its rollback snapshot. Restore one later with:
+
+```bash
+sudo ./install_stability_web_auth.sh \
+  --target /home/bjorn/Bjorn \
+  --restore \
+  /home/bjorn/stability-web-auth-rollback-YYYYMMDD-HHMMSS-XXXXXX
+```
+
+The restore operation creates a recovery snapshot before changing files and
+then verifies the restored service and port 8000.
+
+When the updated files are already installed, set a username and password
+without placing the password in shell history by running:
+
+```bash
+sudo http_auth set bjornadmin
+```
+
+The password must contain at least 12 characters. Bjorn stores a salted scrypt
+verifier in `config/web_auth.json`; the plaintext password is never written to
+disk. To inspect or change the state:
+
+```bash
+sudo http_auth status
+sudo http_auth disable
+sudo http_auth enable
+```
+
+For non-interactive automation, pass the password through standard input rather
+than a command argument:
+
+```bash
+printf '%s\n' "$WEB_AUTH_PASSWORD" |
+  sudo http_auth set bjornadmin --password-stdin
+```
+
+Run the complete isolated and live validation suite in release order with:
+
+```bash
+sudo ./tests/run_stability_web_auth_validation.sh --all \
+  --target /home/bjorn/Bjorn
+```
+
+The suite first runs all unit and integration tests, then validates scanner
+completion, bounded thread use, service shutdown and restart, authentication
+commands, every web route, malformed requests, and credential restoration. The
+live test restores the original credential verifier automatically.
+
+Browsers may first request a protected resource without an Authorization
+header and then repeat it with the stored credentials. The initial request
+still receives `401` as required by HTTP Basic authentication, but only
+malformed or incorrect credentials are written as authentication warnings.
+Rejected POST requests are answered without waiting for an unsent request body,
+so an incomplete browser request cannot block the web interface.
+
+HTTP Basic authentication provides access control but does not encrypt network
+traffic. Use Bjorn only on a trusted local network or place an HTTPS reverse
+proxy in front of it when traffic crosses an untrusted network.
+
 #### Step 4: Configure File Descriptor Limits
 
 To prevent `OSError: [Errno 24] Too many open files`, it's essential to increase the file descriptor limits.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The e-Paper HAT display and web interface make it easy to monitor and interact w
 - **System Attacks**: Conducts brute-force attacks on various services (FTP, SSH, SMB, RDP, Telnet, SQL).
 - **File Stealing**: Extracts data from vulnerable services.
 - **User Interface**: Real-time display on the e-Paper HAT and web interface for monitoring and interaction.
+- **Optional Access Control**: Protects every web route with locally managed credentials when enabled.
 
 ![Bjorn Display](https://github.com/infinition/Bjorn/assets/37984399/bcad830d-77d6-4f3e-833d-473eadd33921)
 
@@ -90,6 +91,16 @@ sudo chmod +x install_bjorn.sh && sudo ./install_bjorn.sh
 ```
 
 For **detailed information** about **installation** process go to [Install Guide](INSTALL.md)
+
+The web interface remains open by default for backwards compatibility. After
+installation, enable password protection without placing the password in shell
+history:
+
+```bash
+sudo http_auth set <username>
+```
+
+Use Bjorn only on networks you own or are explicitly authorized to test.
 
 ## ⚡ Quick Start
 

--- a/actions/scanning.py
+++ b/actions/scanning.py
@@ -441,7 +441,8 @@ class NetworkScanner:
 
             worker_count = min(MAX_PORT_SCAN_WORKERS, len(ports))
             with ThreadPoolExecutor(max_workers=worker_count) as executor:
-                list(executor.map(self.scan, ports))
+                for _ in executor.map(self.scan, ports):
+                    pass
 
     class ScanPorts:
         """
@@ -489,7 +490,8 @@ class NetworkScanner:
             if hosts:
                 worker_count = min(MAX_HOST_SCAN_WORKERS, len(hosts))
                 with ThreadPoolExecutor(max_workers=worker_count) as executor:
-                    list(executor.map(self.scan_host, hosts))
+                    for _ in executor.map(self.scan_host, hosts):
+                        pass
 
             self.outer_instance.sort_and_write_csv(self.csv_scan_file)
 
@@ -565,63 +567,77 @@ class NetworkScanner:
             """
             Reads the source CSV file into a DataFrame.
             """
-            try:
-                self.df = pd.read_csv(self.source_csv_path)
-            except Exception as e:
-                self.logger.error(f"Error in read_csv: {e}")
+            self.df = pd.read_csv(
+                self.source_csv_path,
+                dtype={'Ports': 'string'},
+            )
 
         def calculate_open_ports(self):
             """
             Calculates the total number of open ports for alive hosts.
             """
-            try:
-                alive_df = self.df[self.df['Alive'] == 1].copy()
-                alive_df.loc[:, 'Ports'] = alive_df['Ports'].fillna('')
-                alive_df.loc[:, 'Port Count'] = alive_df['Ports'].apply(lambda x: len(x.split(';')) if x else 0)
-                self.total_open_ports = alive_df['Port Count'].sum()
-            except Exception as e:
-                self.logger.error(f"Error in calculate_open_ports: {e}")
+            alive_df = self.df[self.df['Alive'] == 1].copy()
+            ports = alive_df['Ports'].astype('string').fillna('')
+            port_counts = ports.map(
+                lambda value: sum(
+                    1
+                    for port in value.split(';')
+                    if port.strip()
+                )
+            )
+            self.total_open_ports = int(port_counts.sum())
 
         def calculate_hosts_counts(self):
             """
             Calculates the total and alive host counts.
             """
-            try:
-                # self.all_known_hosts_count = self.df.shape[0] 
-                self.all_known_hosts_count = self.df[self.df['MAC Address'] != 'STANDALONE'].shape[0] 
-                self.alive_hosts_count = self.df[self.df['Alive'] == 1].shape[0]
-            except Exception as e:
-                self.logger.error(f"Error in calculate_hosts_counts: {e}")
+            # self.all_known_hosts_count = self.df.shape[0]
+            self.all_known_hosts_count = self.df[
+                self.df['MAC Address'] != 'STANDALONE'
+            ].shape[0]
+            self.alive_hosts_count = self.df[
+                self.df['Alive'] == 1
+            ].shape[0]
 
         def save_results(self):
             """
             Saves the calculated results to the output CSV file.
             """
-            try:
-                if os.path.exists(self.output_csv_path):
-                    results_df = pd.read_csv(self.output_csv_path)
-                    results_df.loc[0, 'Total Open Ports'] = self.total_open_ports
-                    results_df.loc[0, 'Alive Hosts Count'] = self.alive_hosts_count
-                    results_df.loc[0, 'All Known Hosts Count'] = self.all_known_hosts_count
-                    results_df.to_csv(self.output_csv_path, index=False)
-                else:
-                    self.logger.error(f"File {self.output_csv_path} does not exist.")
-            except Exception as e:
-                self.logger.error(f"Error in save_results: {e}")
+            if not os.path.exists(self.output_csv_path):
+                raise FileNotFoundError(
+                    f"File {self.output_csv_path} does not exist."
+                )
+
+            results_df = pd.read_csv(self.output_csv_path)
+            results_df.loc[0, 'Total Open Ports'] = self.total_open_ports
+            results_df.loc[0, 'Alive Hosts Count'] = self.alive_hosts_count
+            results_df.loc[0, 'All Known Hosts Count'] = (
+                self.all_known_hosts_count
+            )
+            results_df.to_csv(self.output_csv_path, index=False)
 
         def update_livestatus(self):
             """
             Updates the live status of hosts and saves the results.
             """
+            step_name = 'read_csv'
             try:
-                self.read_csv()
-                self.calculate_open_ports()
-                self.calculate_hosts_counts()
-                self.save_results()
-                self.logger.info("Livestatus updated")
-                self.logger.info(f"Results saved to {self.output_csv_path}")
+                for step_name, step in (
+                    ('read_csv', self.read_csv),
+                    ('calculate_open_ports', self.calculate_open_ports),
+                    ('calculate_hosts_counts', self.calculate_hosts_counts),
+                    ('save_results', self.save_results),
+                ):
+                    step()
             except Exception as e:
-                self.logger.error(f"Error in update_livestatus: {e}")
+                self.logger.error(
+                    f"Error updating livestatus during {step_name}: {e}"
+                )
+                return False
+
+            self.logger.info("Livestatus updated")
+            self.logger.info(f"Results saved to {self.output_csv_path}")
+            return True
         
         def clean_scan_results(self, scan_results_dir):
             """

--- a/actions/scanning.py
+++ b/actions/scanning.py
@@ -11,6 +11,8 @@ import netifaces
 import time
 import glob
 import logging
+import subprocess
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from rich.console import Console
 from rich.table import Table
@@ -31,6 +33,16 @@ b_port = None
 b_parent = None
 b_priority = 1
 
+MAX_PORT_SCAN_WORKERS = 32
+MAX_HOST_SCAN_WORKERS = 16
+NMAP_SHUTDOWN_POLL_SECONDS = 0.25
+NMAP_TERMINATE_TIMEOUT_SECONDS = 2
+
+
+class NetworkScanCancelled(RuntimeError):
+    """Raised when an active network scan is cancelled during shutdown."""
+
+
 class NetworkScanner:
     """
     This class handles the entire network scanning process.
@@ -45,9 +57,110 @@ class NetworkScanner:
         self.console = Console()
         self.lock = threading.Lock()
         self.currentdir = shared_data.currentdir
-        self.semaphore = threading.Semaphore(200)  # Limit the number of active threads to 20
         self.nm = nmap.PortScanner()  # Initialize nmap.PortScanner()
         self.running = False
+        self.stop_event = threading.Event()
+        self.discovery_process = None
+
+    def shutdown_requested(self):
+        """Return whether Bjorn has requested application shutdown."""
+        return (
+            (
+                getattr(self, "stop_event", None) is not None
+                and self.stop_event.is_set()
+            )
+            or getattr(self.shared_data, "should_exit", False)
+            or getattr(
+                self.shared_data,
+                "orchestrator_should_exit",
+                False,
+            )
+        )
+
+    def wait_or_cancel(self, timeout):
+        """Wait for a bounded interval while remaining responsive to shutdown."""
+        deadline = time.monotonic() + timeout
+        while True:
+            if self.shutdown_requested():
+                raise NetworkScanCancelled(
+                    "Network scan wait interrupted during shutdown."
+                )
+
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            time.sleep(min(0.1, remaining))
+
+    def terminate_discovery_process(self, process):
+        """Terminate a running Nmap process, escalating if it does not exit."""
+        if process.poll() is not None:
+            return
+
+        process.terminate()
+        try:
+            process.communicate(timeout=NMAP_TERMINATE_TIMEOUT_SECONDS)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.communicate()
+
+    def run_host_discovery(self, network):
+        """
+        Run Nmap host discovery while remaining responsive to shutdown.
+
+        python-nmap waits indefinitely in ``Popen.communicate()``. Running the
+        same Nmap command here in short polling intervals lets Bjorn terminate
+        only an in-flight discovery process when systemd requests a stop. The
+        completed XML is still parsed by python-nmap so downstream behavior
+        remains unchanged.
+        """
+        if self.shutdown_requested():
+            raise NetworkScanCancelled(
+                "Network discovery cancelled before Nmap was started."
+            )
+
+        nmap_path = getattr(self.nm, "_nmap_path", "nmap")
+        command = [
+            nmap_path,
+            "-oX",
+            "-",
+            str(network),
+            "-sn",
+        ]
+        process = subprocess.Popen(
+            command,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        self.discovery_process = process
+
+        try:
+            while True:
+                try:
+                    nmap_output, nmap_error = process.communicate(
+                        timeout=NMAP_SHUTDOWN_POLL_SECONDS,
+                    )
+                    break
+                except subprocess.TimeoutExpired:
+                    if self.shutdown_requested():
+                        self.terminate_discovery_process(process)
+                        raise NetworkScanCancelled(
+                            "Active Nmap discovery terminated during shutdown."
+                        )
+
+            if self.shutdown_requested():
+                raise NetworkScanCancelled(
+                    "Network discovery completed during shutdown."
+                )
+
+            self.nm.analyse_nmap_xml_scan(
+                nmap_xml_output=nmap_output,
+                nmap_err=nmap_error.decode(errors="replace"),
+            )
+        finally:
+            if process.poll() is None:
+                self.terminate_discovery_process(process)
+            self.discovery_process = None
 
     def check_if_csv_scan_file_exists(self, csv_scan_file, csv_result_file, netkbfile):
         """
@@ -299,37 +412,36 @@ class NetworkScanner:
             """
             Scans a specific port on the target IP.
             """
-            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            s.settimeout(2)
+            if self.outer_instance.shutdown_requested():
+                return
             try:
-                con = s.connect((self.target, port))
-                self.open_ports[self.target].append(port)
-                con.close()
-            except:
-                pass
-            finally:
-                s.close()  # Ensure the socket is closed
+                with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+                    sock.settimeout(2)
+                    if sock.connect_ex((self.target, port)) == 0:
+                        with self.outer_instance.lock:
+                            self.open_ports[self.target].append(port)
+            except OSError:
+                # Closed or unreachable ports are expected during a scan.
+                return
 
         def start(self):
             """
             Starts the port scanning process for the specified range and extra ports.
             """
-            try:
-                for port in range(self.portstart, self.portend):
-                    t = threading.Thread(target=self.scan_with_semaphore, args=(port,))
-                    t.start()
-                for port in self.extra_ports:
-                    t = threading.Thread(target=self.scan_with_semaphore, args=(port,))
-                    t.start()
-            except Exception as e:
-                self.logger.info(f"Maximum threads defined in the semaphore reached: {e}")
+            ports = list(dict.fromkeys([
+                *range(self.portstart, self.portend),
+                *self.extra_ports,
+            ]))
+            if not ports:
+                return
+            if self.outer_instance.shutdown_requested():
+                raise NetworkScanCancelled(
+                    "Port scan cancelled during shutdown."
+                )
 
-        def scan_with_semaphore(self, port):
-            """
-            Scans a port using a semaphore to limit concurrent threads.
-            """
-            with self.outer_instance.semaphore:
-                self.scan(port)
+            worker_count = min(MAX_PORT_SCAN_WORKERS, len(ports))
+            with ThreadPoolExecutor(max_workers=worker_count) as executor:
+                list(executor.map(self.scan, ports))
 
     class ScanPorts:
         """
@@ -368,18 +480,27 @@ class NetworkScanner:
                     self.outer_instance.logger.error(f"Error in scan_network_and_write_to_csv (initial write): {e}")
 
             # Use nmap to scan for live hosts
-            self.outer_instance.nm.scan(hosts=str(self.network), arguments='-sn')
-            for host in self.outer_instance.nm.all_hosts():
-                t = threading.Thread(target=self.scan_host, args=(host,))
-                t.start()
+            self.outer_instance.run_host_discovery(self.network)
+            if self.outer_instance.shutdown_requested():
+                raise NetworkScanCancelled(
+                    "Host processing cancelled during shutdown."
+                )
+            hosts = list(self.outer_instance.nm.all_hosts())
+            if hosts:
+                worker_count = min(MAX_HOST_SCAN_WORKERS, len(hosts))
+                with ThreadPoolExecutor(max_workers=worker_count) as executor:
+                    list(executor.map(self.scan_host, hosts))
 
-            time.sleep(5)
             self.outer_instance.sort_and_write_csv(self.csv_scan_file)
 
         def scan_host(self, ip):
             """
             Scans a specific host to check if it is alive and retrieves its hostname and MAC address.
             """
+            if self.outer_instance.shutdown_requested():
+                raise NetworkScanCancelled(
+                    "Host scan cancelled during shutdown."
+                )
             if self.outer_instance.blacklistcheck and ip in self.outer_instance.ip_scan_blacklist:
                 return
             try:
@@ -391,9 +512,12 @@ class NetworkScanner:
                             writer = csv.writer(file)
                             writer.writerow([ip, hostname, mac])
                             self.ip_hostname_list.append((ip, hostname, mac))
+            except NetworkScanCancelled:
+                raise
             except Exception as e:
                 self.outer_instance.logger.error(f"Error getting MAC address or writing to file for IP {ip}: {e}")
-            self.progress += 1
+            with self.outer_instance.lock:
+                self.progress += 1
             time.sleep(0.1)  # Adding a small delay to avoid overwhelming the network
 
         def get_progress(self):
@@ -407,13 +531,20 @@ class NetworkScanner:
             Starts the network and port scanning process.
             """
             self.scan_network_and_write_to_csv()
-            time.sleep(7)
+            self.outer_instance.wait_or_cancel(7)
             self.ip_data = self.outer_instance.GetIpFromCsv(self.outer_instance, self.csv_scan_file)
             self.open_ports = {ip: [] for ip in self.ip_data.ip_list}
-            with Progress() as progress:
+            # Bjorn already runs the scan in its orchestrator thread. Disable
+            # Rich's daemon refresh thread so it cannot outlive a completed
+            # scan and write to stderr while Python is shutting down.
+            with Progress(auto_refresh=False) as progress:
                 task = progress.add_task("[cyan]Scanning IPs...", total=len(self.ip_data.ip_list))
                 for ip in self.ip_data.ip_list:
-                    progress.update(task, advance=1)
+                    if self.outer_instance.shutdown_requested():
+                        raise NetworkScanCancelled(
+                            "Port scan cancelled during shutdown."
+                        )
+                    progress.update(task, advance=1, refresh=True)
                     port_scanner = self.outer_instance.PortScanner(self.outer_instance, ip, self.open_ports, self.portstart, self.portend, self.extra_ports)
                     port_scanner.start()
 
@@ -561,7 +692,12 @@ class NetworkScanner:
             updater.update_livestatus()
             updater.clean_scan_results(self.shared_data.scan_results_dir)
         except Exception as e:
-            self.logger.error(f"Error in scan: {e}")
+            if self.shutdown_requested():
+                self.logger.info(
+                    "Network scan stopped during application shutdown."
+                )
+            else:
+                self.logger.error(f"Error in scan: {e}")
 
     def start(self):
         """
@@ -569,7 +705,11 @@ class NetworkScanner:
         """
         if not self.running:
             self.running = True
-            self.thread = threading.Thread(target=self.scan)
+            self.stop_event.clear()
+            self.thread = threading.Thread(
+                target=self.scan,
+                name="BjornNetworkScanner",
+            )
             self.thread.start()
             logger.info("NetworkScanner started.")
 
@@ -579,6 +719,7 @@ class NetworkScanner:
         """
         if self.running:
             self.running = False
+            self.stop_event.set()
             if self.thread.is_alive():
                 self.thread.join()
             logger.info("NetworkScanner stopped.")

--- a/configure_web_auth.py
+++ b/configure_web_auth.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Configure Bjorn's optional web authentication without plaintext arguments."""
+
+import argparse
+import getpass
+import sys
+from pathlib import Path
+
+from web_auth import CredentialError, CredentialStore
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parent
+CREDENTIAL_FILE = REPOSITORY_ROOT / "config" / "web_auth.json"
+
+
+def set_credentials(store, username, password_stdin=False):
+    """Read a password securely, save its verifier, and enable authentication."""
+    if password_stdin:
+        password = sys.stdin.readline()
+        if password == "":
+            raise CredentialError("No password was provided on standard input.")
+        password = password.rstrip("\r\n")
+    else:
+        password = getpass.getpass("New web password: ")
+        confirmation = getpass.getpass("Confirm web password: ")
+        if password != confirmation:
+            raise CredentialError("Passwords do not match.")
+    store.save(username, password, enabled=True)
+    print(f"Web authentication enabled for user '{username}'.")
+
+
+def build_parser():
+    """Build the command-line argument parser."""
+    parser = argparse.ArgumentParser(
+        description="Configure optional authentication for Bjorn's web interface."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    set_parser = subparsers.add_parser(
+        "set",
+        help="set credentials and enable authentication",
+    )
+    set_parser.add_argument("username")
+    set_parser.add_argument(
+        "--password-stdin",
+        action="store_true",
+        help="read one password line from standard input",
+    )
+    subparsers.add_parser("enable", help="enable existing credentials")
+    subparsers.add_parser("disable", help="disable authentication")
+    subparsers.add_parser("status", help="show authentication status")
+    return parser
+
+
+def main(argv=None):
+    """Run the requested credential-management command."""
+    arguments = build_parser().parse_args(argv)
+    store = CredentialStore(CREDENTIAL_FILE)
+
+    try:
+        if arguments.command == "set":
+            set_credentials(
+                store,
+                arguments.username,
+                password_stdin=arguments.password_stdin,
+            )
+        elif arguments.command == "enable":
+            store.set_enabled(True)
+            print("Web authentication enabled.")
+        elif arguments.command == "disable":
+            if store.is_configured():
+                store.set_enabled(False)
+            elif store.path.exists():
+                raise CredentialError(
+                    "Credential file is invalid; run 'set' to replace it."
+                )
+            print("Web authentication disabled.")
+        elif arguments.command == "status":
+            configured = store.is_configured()
+            enabled = store.auth_required()
+            print(f"Credentials configured: {'yes' if configured else 'no'}")
+            print(f"Authentication enabled: {'yes' if enabled else 'no'}")
+    except CredentialError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/display.py
+++ b/display.py
@@ -33,6 +33,7 @@ class Display:
     def __init__(self, shared_data):
         """Initialize the display and start the main image and shared data update threads."""
         self.shared_data = shared_data
+        self.shutdown_event = threading.Event()
         self.config = self.shared_data.config
         self.shared_data.bjornstatustext2 = "Awakening..."
         self.commentaire_ia = Commentaireia()
@@ -60,20 +61,54 @@ class Display:
             logger.error(f"Error during display initialization: {e}")
             raise
 
-        self.main_image_thread = threading.Thread(target=self.update_main_image)
-        self.main_image_thread.daemon = True
+        self.main_image_thread = threading.Thread(
+            target=self.update_main_image,
+            name="BjornDisplayImage",
+        )
         self.main_image_thread.start()
 
-        self.update_shared_data_thread = threading.Thread(target=self.schedule_update_shared_data)
-        self.update_shared_data_thread.daemon = True
+        self.update_shared_data_thread = threading.Thread(
+            target=self.schedule_update_shared_data,
+            name="BjornDisplaySharedData",
+        )
         self.update_shared_data_thread.start()
 
-        self.update_vuln_count_thread = threading.Thread(target=self.schedule_update_vuln_count)
-        self.update_vuln_count_thread.daemon = True
+        self.update_vuln_count_thread = threading.Thread(
+            target=self.schedule_update_vuln_count,
+            name="BjornDisplayVulnerabilityCount",
+        )
         self.update_vuln_count_thread.start()
 
         self.scale_factor_x = self.shared_data.scale_factor_x
         self.scale_factor_y = self.shared_data.scale_factor_y
+
+    def should_stop(self):
+        """Return whether display work has been asked to stop."""
+        return (
+            self.shutdown_event.is_set()
+            or self.shared_data.display_should_exit
+        )
+
+    def wait_or_stop(self, timeout):
+        """Wait for a delay, returning early when shutdown is requested."""
+        return self.shutdown_event.wait(timeout) or self.should_stop()
+
+    def request_stop(self):
+        """Wake every display worker and request a clean shutdown."""
+        self.shared_data.display_should_exit = True
+        self.shutdown_event.set()
+
+    def background_threads(self):
+        """Return the display-owned worker threads for lifecycle joins."""
+        return [
+            self.main_image_thread,
+            self.update_shared_data_thread,
+            self.update_vuln_count_thread,
+        ]
+
+    def close_hardware(self):
+        """Power down the EPD and release GPIO callback resources."""
+        self.epd_helper.shutdown()
 
     def get_frise_position(self):
         """Get the frise position based on the display type."""
@@ -86,28 +121,35 @@ class Display:
 
     def schedule_update_shared_data(self):
         """Periodically update the shared data with the latest system information."""
-        while not self.shared_data.display_should_exit:
+        while not self.should_stop():
             self.update_shared_data()
-            time.sleep(25)
+            if self.wait_or_stop(25):
+                break
 
     def schedule_update_vuln_count(self):
         """Periodically update the vulnerability count on the display."""
-        while not self.shared_data.display_should_exit:
+        while not self.should_stop():
             self.update_vuln_count()
-            time.sleep(300)
+            if self.wait_or_stop(300):
+                break
 
     def update_main_image(self):
         """Update the main image on the display with the latest immagegen data."""
-        while not self.shared_data.display_should_exit:
+        while not self.should_stop():
             try:
                 self.shared_data.update_image_randomizer()
                 if self.shared_data.imagegen:
                     self.main_image = self.shared_data.imagegen
                 else:
                     logger.error("No image generated for current status.")
-                time.sleep(random.uniform(self.shared_data.image_display_delaymin, self.shared_data.image_display_delaymax))
+                if self.wait_or_stop(random.uniform(
+                    self.shared_data.image_display_delaymin,
+                    self.shared_data.image_display_delaymax,
+                )):
+                    break
             except Exception as e:
-                logger.error(f"An error occurred in update_main_image: {e}")
+                if not self.should_stop():
+                    logger.error(f"An error occurred in update_main_image: {e}")
 
     def get_open_files(self):
         """Get the number of open FD files on the system."""
@@ -278,7 +320,7 @@ class Display:
     def run(self):
         """Main loop for updating the EPD display with shared data."""
         self.manual_mode_txt = ""
-        while not self.shared_data.display_should_exit:
+        while not self.should_stop():
             try:
                 self.epd_helper.init_partial_update()
                 self.display_comment(self.shared_data.bjornorch_status)
@@ -353,9 +395,11 @@ class Display:
                     img_file.flush()
                     os.fsync(img_file.fileno())
                 
-                time.sleep(self.shared_data.screen_delay)
+                if self.wait_or_stop(self.shared_data.screen_delay):
+                    break
             except Exception as e:
-                logger.error(f"An error occurred: {e}")
+                if not self.should_stop():
+                    logger.error(f"An error occurred: {e}")
 
 def handle_exit_display(signum, frame, display_thread):
     """Handle the exit signal and close the display."""

--- a/epd_helper.py
+++ b/epd_helper.py
@@ -8,13 +8,15 @@ logger = logging.getLogger(__name__)
 class EPDHelper:
     def __init__(self, epd_type):
         self.epd_type = epd_type
+        self.epd_module = None
+        self._shutdown_complete = False
         self.epd = self._load_epd_module()
 
     def _load_epd_module(self):
         try:
             epd_module_name = f'resources.waveshare_epd.{self.epd_type}'
-            epd_module = importlib.import_module(epd_module_name)
-            return epd_module.EPD()
+            self.epd_module = importlib.import_module(epd_module_name)
+            return self.epd_module.EPD()
         except ImportError as e:
             logger.error(f"EPD module {self.epd_type} not found: {e}")
             raise
@@ -66,3 +68,70 @@ class EPDHelper:
         except Exception as e:
             logger.error(f"Error clearing EPD: {e}")
             raise
+
+    def shutdown(self):
+        """Power down the panel and release gpiozero/lgpio resources."""
+        if self._shutdown_complete:
+            return
+        self._shutdown_complete = True
+
+        try:
+            if hasattr(self.epd, "sleep"):
+                self.epd.sleep()
+        except Exception as e:
+            logger.warning(f"Error putting EPD into sleep mode: {e}")
+
+        epdconfig = getattr(self.epd_module, "epdconfig", None)
+        implementation = getattr(epdconfig, "implementation", None)
+        closed_devices = set()
+        for attribute in (
+            "GPIO_RST_PIN",
+            "GPIO_DC_PIN",
+            "GPIO_CS_PIN",
+            "GPIO_PWR_PIN",
+            "GPIO_BUSY_PIN",
+        ):
+            device = getattr(implementation, attribute, None)
+            if device is None or id(device) in closed_devices:
+                continue
+            closed_devices.add(id(device))
+            try:
+                device.close()
+            except Exception as e:
+                logger.warning(
+                    f"Error closing EPD GPIO device {attribute}: {e}"
+                )
+
+        try:
+            import gpiozero
+
+            pin_factory = getattr(gpiozero.Device, "pin_factory", None)
+            if pin_factory is not None:
+                pin_factory.close()
+        except ImportError:
+            # Non-Raspberry Pi backends do not use gpiozero.
+            pass
+        except Exception as e:
+            logger.warning(f"Error closing gpiozero pin factory: {e}")
+
+        try:
+            import lgpio
+
+            notify_thread = getattr(lgpio, "_notify_thread", None)
+            if notify_thread is not None:
+                notify_thread.stop()
+                notify_handle = getattr(notify_thread, "_notify", None)
+                if notify_handle is not None:
+                    lgpio.notify_close(notify_handle)
+                notify_thread.join(timeout=1)
+                if notify_thread.is_alive():
+                    logger.warning(
+                        "lgpio notification thread did not stop "
+                        "within 1 second"
+                    )
+        except ImportError:
+            pass
+        except Exception as e:
+            logger.warning(
+                f"Error stopping lgpio notification thread: {e}"
+            )

--- a/install_bjorn.sh
+++ b/install_bjorn.sh
@@ -12,27 +12,65 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m'
 
-# Logging configuration
-LOG_DIR="/var/log/bjorn_install"
-mkdir -p "$LOG_DIR"
-LOG_FILE="$LOG_DIR/bjorn_install_$(date +%Y%m%d_%H%M%S).log"
-VERBOSE=false
-
 # Global variables
-BJORN_USER="bjorn"
-BJORN_PATH="/home/${BJORN_USER}/Bjorn"
+BJORN_USER="${BJORN_USER:-bjorn}"
+BJORN_PATH="${BJORN_PATH:-/home/${BJORN_USER}/Bjorn}"
+HTTP_AUTH_COMMAND_PATH="${HTTP_AUTH_COMMAND_PATH:-/usr/local/sbin/http_auth}"
 CURRENT_STEP=0
-TOTAL_STEPS=8
-
-if [[ "$1" == "--help" ]]; then
-    echo "Usage: sudo ./install_bjorn.sh"
-    echo "Make sure you have the necessary permissions and that all dependencies are met."
-    exit 0
-fi
+FULL_INSTALL_STEPS=(
+    "Checking system compatibility"
+    "Installing system dependencies"
+    "Configuring system limits"
+    "Configuring interfaces"
+    "Setting up BJORN"
+    "Installing optional web-authentication tools"
+    "Configuring USB Gadget"
+    "Setting up services"
+    "Verifying installation"
+)
+TOTAL_STEPS="${#FULL_INSTALL_STEPS[@]}"
 
 # Function to display progress
 show_progress() {
     echo -e "${BLUE}Step $CURRENT_STEP of $TOTAL_STEPS: $1${NC}"
+}
+
+show_install_plan() {
+    local step_name
+
+    echo -e "${BLUE}BJORN full installation plan:${NC}"
+    for step_name in "${FULL_INSTALL_STEPS[@]}"; do
+        CURRENT_STEP=$((CURRENT_STEP + 1))
+        show_progress "$step_name"
+    done
+    echo
+    echo -e "${YELLOW}Web authentication is optional.${NC}"
+    echo "If enabled, the password is entered securely and stored only as a"
+    echo "salted verifier. No installation changes are performed by this view."
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    case "${1:-}" in
+        --help)
+            echo "Usage: sudo ./install_bjorn.sh"
+            echo "       ./install_bjorn.sh --show-plan"
+            echo "Make sure you have the necessary permissions and that all dependencies are met."
+            exit 0
+            ;;
+        --show-plan)
+            show_install_plan
+            exit 0
+            ;;
+    esac
+fi
+
+# Logging configuration
+LOG_DIR="${LOG_DIR:-/var/log/bjorn_install}"
+LOG_FILE="${LOG_FILE:-$LOG_DIR/bjorn_install_$(date +%Y%m%d_%H%M%S).log}"
+VERBOSE=false
+
+initialize_logging() {
+    mkdir -p "$LOG_DIR"
 }
 
 # Logging function
@@ -54,33 +92,22 @@ log() {
 
 # Error handling function
 handle_error() {
-    local error_code=$?
-    local error_message=$1
+    local error_message="$1"
+    local error_code="${2:-1}"
     log "ERROR" "An error occurred during: $error_message (Error code: $error_code)"
     log "ERROR" "Check the log file for details: $LOG_FILE"
-
-    echo -e "\n${RED}Would you like to:"
-    echo "1. Retry this step"
-    echo "2. Skip this step (not recommended)"
-    echo "3. Exit installation${NC}"
-    read -r choice
-
-    case $choice in
-        1) return 1 ;; # Retry
-        2) return 0 ;; # Skip
-        3) clean_exit 1 ;; # Exit
-        *) handle_error "$error_message" ;; # Invalid choice
-    esac
+    echo -e "${RED}The installation cannot safely continue.${NC}"
+    clean_exit "$error_code"
 }
 
 # Function to check command success
 check_success() {
-    if [ $? -eq 0 ]; then
+    local command_status=$?
+    if [ "$command_status" -eq 0 ]; then
         log "SUCCESS" "$1"
         return 0
     else
-        handle_error "$1"
-        return $?
+        handle_error "$1" "$command_status"
     fi
 }
 
@@ -327,10 +354,77 @@ setup_bjorn() {
     # Set correct permissions
     chown -R $BJORN_USER:$BJORN_USER /home/$BJORN_USER/Bjorn
     chmod -R 755 /home/$BJORN_USER/Bjorn
-    
+
     # Add bjorn user to necessary groups
     usermod -a -G spi,gpio,i2c $BJORN_USER
     check_success "Added bjorn user to required groups"
+}
+
+# Configure optional web authentication without exposing a password in
+# arguments, command history, or the installer log.
+configure_web_auth() {
+    local install_auth_tools
+    local enable_auth
+    local web_username
+
+    if [ ! -f "$BJORN_PATH/configure_web_auth.py" ]; then
+        log "ERROR" "Web-authentication helper not found: $BJORN_PATH/configure_web_auth.py"
+        handle_error "Web authentication configuration"
+        return
+    fi
+
+    echo -e "${BLUE}Optional web-authentication tools:${NC}"
+    read -r -p "Install the http_auth management command? (Y/n): " install_auth_tools
+    case "$install_auth_tools" in
+        n|N)
+            log "INFO" "Optional web-authentication tools were not installed"
+            log "INFO" "Authentication remains unconfigured"
+            return
+            ;;
+        *)
+            chmod 755 "$BJORN_PATH/configure_web_auth.py"
+            check_success "Prepared web-authentication management helper"
+            install -d -m 755 "$(dirname -- "$HTTP_AUTH_COMMAND_PATH")"
+            ln -sfn "$BJORN_PATH/configure_web_auth.py" \
+                "$HTTP_AUTH_COMMAND_PATH"
+            check_success "Installed http_auth management command"
+            ;;
+    esac
+
+    read -r -p "Protect the web interface with a password now? (y/N): " enable_auth
+    case "$enable_auth" in
+        y|Y)
+            read -r -p "Web username [bjorn]: " web_username
+            web_username="${web_username:-bjorn}"
+            while true; do
+                if python3 "$BJORN_PATH/configure_web_auth.py" \
+                    set "$web_username"; then
+                    log "SUCCESS" "Configured web authentication"
+                    chown "$BJORN_USER:$BJORN_USER" \
+                        "$BJORN_PATH/config/web_auth.json"
+                    check_success \
+                        "Set web-authentication credential ownership"
+                    chmod 600 "$BJORN_PATH/config/web_auth.json"
+                    check_success \
+                        "Secured web-authentication credential file"
+                    break
+                fi
+
+                log "WARNING" "Web-authentication credential setup failed"
+                read -r -p "Retry credential setup? (Y/n): " retry_auth
+                case "$retry_auth" in
+                    n|N)
+                        log "INFO" "Web authentication left unconfigured"
+                        return 0
+                        ;;
+                esac
+            done
+            ;;
+        *)
+            log "INFO" "Web authentication left unconfigured"
+            log "INFO" "Configure it later with: sudo http_auth set <username>"
+            ;;
+    esac
 }
 
 
@@ -380,9 +474,13 @@ EOF
 
     # Enable and start services
     systemctl daemon-reload
+    check_success "Reloaded systemd configuration"
     systemctl enable bjorn.service
+    check_success "Enabled Bjorn service"
+    systemctl restart bjorn.service
+    check_success "Started Bjorn service"
 
-    check_success "Services setup completed"
+    log "SUCCESS" "Services setup completed"
 }
 
 # Configure USB Gadget
@@ -484,22 +582,41 @@ EOF
 
 # Verify installation
 verify_installation() {
+    local http_status="000"
+    local second
+    local verification_failed=0
+
     log "INFO" "Verifying installation..."
-    
-    # Check if services are running
+
+    for ((second = 0; second <= 90; second++)); do
+        http_status="$(
+            curl --silent --output /dev/null --write-out '%{http_code}' \
+                --max-time 2 http://127.0.0.1:8000/ || true
+        )"
+        if [[ "$http_status" == "200" || "$http_status" == "401" ]]; then
+            break
+        fi
+        if ((second % 5 == 0)); then
+            log "INFO" "Waiting for web interface: ${second}/90 seconds"
+        fi
+        sleep 1
+    done
+
     if ! systemctl is-active --quiet bjorn.service; then
-        log "WARNING" "BJORN service is not running"
+        log "ERROR" "BJORN service is not running"
+        verification_failed=1
     else
         log "SUCCESS" "BJORN service is running"
     fi
-    
-    # Check web interface
-    sleep 5
-    if curl -s http://localhost:8000 > /dev/null; then
-        log "SUCCESS" "Web interface is accessible"
+
+    if [[ "$http_status" == "200" || "$http_status" == "401" ]]; then
+        log "SUCCESS" "Web interface returned HTTP $http_status on port 8000"
     else
-        log "WARNING" "Web interface is not responding"
+        log "ERROR" "Web interface is not responding (HTTP $http_status)"
+        verification_failed=1
     fi
+
+    return "$verification_failed"
 }
 
 # Clean exit function
@@ -517,13 +634,14 @@ clean_exit() {
 
 # Main installation process
 main() {
-    log "INFO" "Starting BJORN installation..."
-
     # Check if script is run as root
     if [ "$(id -u)" -ne 0 ]; then
         echo "This script must be run as root. Please use 'sudo'."
         exit 1
     fi
+
+    initialize_logging
+    log "INFO" "Starting BJORN installation..."
 
     echo -e "${BLUE}BJORN Installation Options:${NC}"
     echo "1. Full installation (recommended)"
@@ -569,14 +687,19 @@ main() {
             CURRENT_STEP=5; show_progress "Setting up BJORN"
             setup_bjorn
 
-            CURRENT_STEP=6; show_progress "Configuring USB Gadget"
+            CURRENT_STEP=6; show_progress "Installing optional web-authentication tools"
+            configure_web_auth
+
+            CURRENT_STEP=7; show_progress "Configuring USB Gadget"
             configure_usb_gadget
 
-            CURRENT_STEP=7; show_progress "Setting up services"
+            CURRENT_STEP=8; show_progress "Setting up services"
             setup_services
 
-            CURRENT_STEP=8; show_progress "Verifying installation"
-            verify_installation
+            CURRENT_STEP=9; show_progress "Verifying installation"
+            if ! verify_installation; then
+                clean_exit 1
+            fi
             ;;
         2)
             echo "Custom installation - select components to install:"
@@ -584,6 +707,7 @@ main() {
             read -p "Configure system limits? (y/n): " limits
             read -p "Configure interfaces? (y/n): " interfaces
             read -p "Setup BJORN? (y/n): " bjorn
+            read -p "Configure web authentication? (y/n): " web_auth
             read -p "Configure USB Gadget? (y/n): " usb_gadget
             read -p "Setup services? (y/n): " services
 
@@ -591,9 +715,12 @@ main() {
             [ "$limits" = "y" ] && configure_system_limits
             [ "$interfaces" = "y" ] && configure_interfaces
             [ "$bjorn" = "y" ] && setup_bjorn
+            [ "$web_auth" = "y" ] && configure_web_auth
             [ "$usb_gadget" = "y" ] && configure_usb_gadget
             [ "$services" = "y" ] && setup_services
-            verify_installation
+            if ! verify_installation; then
+                clean_exit 1
+            fi
             ;;
         *)
             log "ERROR" "Invalid option selected"
@@ -614,7 +741,12 @@ main() {
     echo "   - Default Gateway: 172.20.2.1"
     echo "   - DNS Servers: 8.8.8.8, 8.8.4.4"
     echo "2. Web interface will be available at: http://[device-ip]:8000"
-    echo "3. Make sure your e-Paper HAT (2.13-inch) is properly connected"
+    if [ -L "$HTTP_AUTH_COMMAND_PATH" ]; then
+        echo "3. Web authentication can be managed with: sudo http_auth"
+    else
+        echo "3. Optional web-authentication tools were not installed"
+    fi
+    echo "4. Make sure your e-Paper HAT (2.13-inch) is properly connected"
 
     read -p "Would you like to reboot now? (y/n): " reboot_now
     if [ "$reboot_now" = "y" ]; then
@@ -629,8 +761,6 @@ main() {
     fi
 }
 
-main
-
-
-
-
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+fi

--- a/install_stability_web_auth.sh
+++ b/install_stability_web_auth.sh
@@ -111,7 +111,7 @@ EOF
 
 fail() {
     error "$*"
-    return 1
+    exit 1
 }
 
 require_value() {

--- a/install_stability_web_auth.sh
+++ b/install_stability_web_auth.sh
@@ -1,0 +1,589 @@
+#!/usr/bin/env bash
+#
+# Atomically install Bjorn's stability, lifecycle, scanner-worker, and optional
+# web-authentication improvements into an existing installation. The script
+# creates one rollback snapshot for the complete feature set and restores it
+# automatically if validation, installation, or startup fails.
+
+set -Eeuo pipefail
+
+SOURCE_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+TARGET_DIR="/home/bjorn/Bjorn"
+SERVICE_NAME="bjorn.service"
+COMMAND_PATH="/usr/local/sbin/http_auth"
+CREDENTIAL_SOURCE=""
+USERNAME=""
+ROLLBACK_ROOT="/home/bjorn"
+ROLLBACK_DIR=""
+RESTORE_SOURCE=""
+INSTALL_STARTED=0
+HTTP_STATUS=""
+WEB_PORT=8000
+PORT_RELEASE_TIMEOUT=90
+
+if [[ -t 1 && -z "${NO_COLOR:-}" ]]; then
+    RED=$'\033[0;31m'
+    GREEN=$'\033[0;32m'
+    YELLOW=$'\033[1;33m'
+    BLUE=$'\033[0;34m'
+    CYAN=$'\033[0;36m'
+    BOLD=$'\033[1m'
+    DIM=$'\033[2m'
+    NC=$'\033[0m'
+else
+    RED=""
+    GREEN=""
+    YELLOW=""
+    BLUE=""
+    CYAN=""
+    BOLD=""
+    DIM=""
+    NC=""
+fi
+
+banner() {
+    local operation="$1"
+    printf '\n%b%s%b\n' "$BOLD$CYAN" \
+        "Bjorn stability and web-auth installer" "$NC"
+    printf '%b%-12s%b %s\n' "$DIM" "Operation:" "$NC" "$operation"
+    printf '%b%-12s%b %s\n' "$DIM" "Target:" "$NC" "$TARGET_DIR"
+    printf '%b%-12s%b %s\n\n' "$DIM" "Service:" "$NC" "$SERVICE_NAME"
+}
+
+step() {
+    local number="$1"
+    local total="$2"
+    shift 2
+    printf '%bStep %s of %s:%b %s\n' \
+        "$BOLD$BLUE" "$number" "$total" "$NC" "$*"
+}
+
+info() {
+    printf '%b[INFO]%b %s\n' "$BLUE" "$NC" "$*"
+}
+
+success() {
+    printf '%b[OK]%b %s\n' "$GREEN" "$NC" "$*"
+}
+
+warning() {
+    printf '%b[WARNING]%b %s\n' "$YELLOW" "$NC" "$*" >&2
+}
+
+error() {
+    printf '%b[ERROR]%b %s\n' "$RED" "$NC" "$*" >&2
+}
+
+summary_row() {
+    local label="$1"
+    shift
+    printf '  %b%-20s%b %s\n' "$BOLD" "$label" "$NC" "$*"
+}
+
+complete() {
+    printf '\n%b[PASS]%b %s\n' "$BOLD$GREEN" "$NC" "$*"
+}
+
+usage() {
+    cat <<'EOF'
+Usage:
+  sudo ./install_stability_web_auth.sh [options]
+
+Options:
+  --target PATH          Existing Bjorn installation (default: /home/bjorn/Bjorn)
+  --service UNIT         Systemd service name (default: bjorn.service)
+  --command-path PATH    Management command (default: /usr/local/sbin/http_auth)
+  --credentials FILE     Reuse an existing web_auth.json credential file
+  --username USER        Prompt for a new password and enable this username
+  --rollback-root PATH   Directory for rollback snapshots (default: /home/bjorn)
+  --restore SNAPSHOT     Restore a snapshot created by this installer
+  -h, --help             Show this help
+
+Use either --credentials or --username, not both. Without either option, all
+stability files are installed but authentication remains unconfigured.
+Use --restore by itself to return to a previous installer snapshot. A recovery
+snapshot of the current state is created before the restore begins.
+When restoring Bjorn's original non-reusable web socket, the installer waits
+for port 8000 to leave TIME_WAIT before restarting the service.
+Colors are enabled automatically on a terminal. Set NO_COLOR=1 to disable them.
+EOF
+}
+
+fail() {
+    error "$*"
+    return 1
+}
+
+require_value() {
+    local option="$1"
+    local value="${2:-}"
+    [[ -n "$value" ]] || fail "$option requires a value"
+}
+
+while (($#)); do
+    case "$1" in
+        --target)
+            require_value "$1" "${2:-}"
+            TARGET_DIR="$2"
+            shift 2
+            ;;
+        --service)
+            require_value "$1" "${2:-}"
+            SERVICE_NAME="$2"
+            shift 2
+            ;;
+        --command-path)
+            require_value "$1" "${2:-}"
+            COMMAND_PATH="$2"
+            shift 2
+            ;;
+        --credentials)
+            require_value "$1" "${2:-}"
+            CREDENTIAL_SOURCE="$2"
+            shift 2
+            ;;
+        --username)
+            require_value "$1" "${2:-}"
+            USERNAME="$2"
+            shift 2
+            ;;
+        --rollback-root)
+            require_value "$1" "${2:-}"
+            ROLLBACK_ROOT="$2"
+            shift 2
+            ;;
+        --restore)
+            require_value "$1" "${2:-}"
+            RESTORE_SOURCE="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            fail "Unknown option: $1"
+            ;;
+    esac
+done
+
+[[ $EUID -eq 0 ]] || fail "Run this installer with sudo."
+[[ -z "$CREDENTIAL_SOURCE" || -z "$USERNAME" ]] || \
+    fail "Use either --credentials or --username, not both."
+[[ -z "$RESTORE_SOURCE" || \
+   ( -z "$CREDENTIAL_SOURCE" && -z "$USERNAME" ) ]] || \
+    fail "Do not combine --restore with --credentials or --username."
+
+SOURCE_DIR="$(readlink -f -- "$SOURCE_DIR")"
+TARGET_DIR="$(readlink -f -- "$TARGET_DIR")"
+ROLLBACK_ROOT="$(readlink -f -- "$ROLLBACK_ROOT")"
+COMMAND_PATH="$(realpath --canonicalize-missing --no-symlinks -- "$COMMAND_PATH")"
+if [[ -n "$RESTORE_SOURCE" ]]; then
+    [[ -d "$RESTORE_SOURCE" ]] || \
+        fail "Restore snapshot not found: $RESTORE_SOURCE"
+    RESTORE_SOURCE="$(readlink -f -- "$RESTORE_SOURCE")"
+fi
+
+[[ -d "$TARGET_DIR" ]] || fail "Target directory not found: $TARGET_DIR"
+[[ -f "$TARGET_DIR/Bjorn.py" ]] || fail "Bjorn.py not found in: $TARGET_DIR"
+systemctl cat "$SERVICE_NAME" >/dev/null || fail "Service not found: $SERVICE_NAME"
+
+if [[ -n "$RESTORE_SOURCE" ]]; then
+    OPERATION_MODE="Restore"
+else
+    OPERATION_MODE="Installation"
+fi
+banner "$OPERATION_MODE"
+step 1 5 "Validate inputs and create a recovery snapshot"
+
+if [[ -z "$RESTORE_SOURCE" ]]; then
+    REQUIRED_SOURCE_FILES=(
+        actions/scanning.py
+        Bjorn.py
+        display.py
+        epd_helper.py
+        web_auth.py
+        configure_web_auth.py
+        webapp.py
+        shared.py
+    )
+    for relative_path in "${REQUIRED_SOURCE_FILES[@]}"; do
+        [[ -f "$SOURCE_DIR/$relative_path" ]] || \
+            fail "Required source file missing: $SOURCE_DIR/$relative_path"
+    done
+
+    if [[ -n "$CREDENTIAL_SOURCE" ]]; then
+        CREDENTIAL_SOURCE="$(readlink -f -- "$CREDENTIAL_SOURCE")"
+        [[ -f "$CREDENTIAL_SOURCE" ]] || \
+            fail "Credential file not found: $CREDENTIAL_SOURCE"
+        PYTHONPATH="$SOURCE_DIR" python3 - "$CREDENTIAL_SOURCE" <<'PY'
+import sys
+
+from web_auth import CredentialStore
+
+credential_file = sys.argv[1]
+if not CredentialStore(credential_file).is_configured():
+    raise SystemExit(f"Credential file is invalid: {credential_file}")
+PY
+    fi
+
+    python3 -m py_compile \
+        "$SOURCE_DIR/actions/scanning.py" \
+        "$SOURCE_DIR/Bjorn.py" \
+        "$SOURCE_DIR/display.py" \
+        "$SOURCE_DIR/epd_helper.py" \
+        "$SOURCE_DIR/web_auth.py" \
+        "$SOURCE_DIR/configure_web_auth.py" \
+        "$SOURCE_DIR/webapp.py" \
+        "$SOURCE_DIR/shared.py"
+fi
+
+TARGET_OWNER="$(stat -c '%U' -- "$TARGET_DIR")"
+TARGET_GROUP="$(stat -c '%G' -- "$TARGET_DIR")"
+TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
+ROLLBACK_DIR="$(
+    mktemp -d "$ROLLBACK_ROOT/stability-web-auth-rollback-$TIMESTAMP-XXXXXX"
+)"
+mkdir -p "$ROLLBACK_DIR/files"
+
+MANAGED_PATHS=(
+    actions/scanning.py
+    Bjorn.py
+    display.py
+    epd_helper.py
+    webapp.py
+    shared.py
+    web_auth.py
+    configure_web_auth.py
+    config/web_auth.json
+    .gitignore
+)
+
+for relative_path in "${MANAGED_PATHS[@]}"; do
+    if [[ -e "$TARGET_DIR/$relative_path" ]]; then
+        mkdir -p "$ROLLBACK_DIR/files/$(dirname -- "$relative_path")"
+        cp -a -- "$TARGET_DIR/$relative_path" \
+            "$ROLLBACK_DIR/files/$relative_path"
+    else
+        printf '%s\n' "$relative_path" >>"$ROLLBACK_DIR/absent-before-install.txt"
+    fi
+done
+
+if [[ -e "$COMMAND_PATH" || -L "$COMMAND_PATH" ]]; then
+    mkdir -p "$ROLLBACK_DIR/system-command"
+    cp -a -- "$COMMAND_PATH" "$ROLLBACK_DIR/system-command/value"
+else
+    touch "$ROLLBACK_DIR/system-command-absent"
+fi
+
+validate_snapshot() {
+    local snapshot_dir="$1"
+    local relative_path
+    local saved
+    local absent
+
+    [[ -d "$snapshot_dir/files" ]] || \
+        fail "Snapshot has no files directory: $snapshot_dir"
+
+    for relative_path in "${MANAGED_PATHS[@]}"; do
+        saved=0
+        absent=0
+        [[ -e "$snapshot_dir/files/$relative_path" || \
+           -L "$snapshot_dir/files/$relative_path" ]] && saved=1
+        if [[ -f "$snapshot_dir/absent-before-install.txt" ]] && \
+           grep -qxF "$relative_path" \
+               "$snapshot_dir/absent-before-install.txt"; then
+            absent=1
+        fi
+        ((saved + absent == 1)) || \
+            fail "Snapshot state is incomplete for: $relative_path"
+    done
+
+    saved=0
+    absent=0
+    [[ -e "$snapshot_dir/system-command/value" || \
+       -L "$snapshot_dir/system-command/value" ]] && saved=1
+    [[ -f "$snapshot_dir/system-command-absent" ]] && absent=1
+    ((saved + absent == 1)) || \
+        fail "Snapshot state is incomplete for: $COMMAND_PATH"
+}
+
+restore_snapshot() {
+    local snapshot_dir="$1"
+    local relative_path
+    local saved_path
+    info "Restoring snapshot from: $snapshot_dir"
+
+    for relative_path in "${MANAGED_PATHS[@]}"; do
+        saved_path="$snapshot_dir/files/$relative_path"
+        if [[ -e "$saved_path" || -L "$saved_path" ]]; then
+            mkdir -p "$TARGET_DIR/$(dirname -- "$relative_path")"
+            rm -f -- "$TARGET_DIR/$relative_path"
+            cp -a -- "$saved_path" "$TARGET_DIR/$relative_path"
+        else
+            rm -f -- "$TARGET_DIR/$relative_path"
+        fi
+    done
+
+    rm -f -- "$COMMAND_PATH"
+    if [[ -e "$snapshot_dir/system-command/value" || \
+          -L "$snapshot_dir/system-command/value" ]]; then
+        mkdir -p "$(dirname -- "$COMMAND_PATH")"
+        cp -a -- "$snapshot_dir/system-command/value" "$COMMAND_PATH"
+    fi
+}
+
+wait_for_web_port_release() {
+    local webapp_file="$TARGET_DIR/webapp.py"
+    local second
+    local reuse_address=0
+
+    if [[ -f "$webapp_file" ]] && \
+       grep -Eq 'allow_reuse_address[[:space:]]*=[[:space:]]*True' \
+           "$webapp_file"; then
+        reuse_address=1
+    fi
+
+    for ((second = 0; second <= PORT_RELEASE_TIMEOUT; second++)); do
+        if python3 - "$WEB_PORT" "$reuse_address" <<'PY'
+import socket
+import sys
+
+port = int(sys.argv[1])
+reuse_address = bool(int(sys.argv[2]))
+probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+try:
+    if reuse_address:
+        probe.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    probe.bind(("", port))
+except OSError:
+    raise SystemExit(1)
+finally:
+    probe.close()
+PY
+        then
+            success "Port $WEB_PORT is available"
+            return 0
+        fi
+        if ((second % 5 == 0)); then
+            info "Waiting for port $WEB_PORT release: " \
+                 "$second/$PORT_RELEASE_TIMEOUT seconds"
+        fi
+        sleep 1
+    done
+
+    fail "Port $WEB_PORT did not become available within " \
+         "$PORT_RELEASE_TIMEOUT seconds."
+}
+
+start_and_verify() {
+    if systemctl is-active --quiet "$SERVICE_NAME"; then
+        fail "$SERVICE_NAME must be inactive before startup verification."
+        return 1
+    fi
+
+    wait_for_web_port_release
+    systemctl reset-failed "$SERVICE_NAME"
+    systemctl start "$SERVICE_NAME"
+
+    HTTP_STATUS=""
+    for _ in {1..30}; do
+        HTTP_STATUS="$(
+            curl --silent --output /dev/null --write-out '%{http_code}' \
+                --max-time 2 "http://127.0.0.1:$WEB_PORT/" || true
+        )"
+        if [[ "$HTTP_STATUS" == "200" || "$HTTP_STATUS" == "401" ]]; then
+            break
+        fi
+        sleep 1
+    done
+    if ! systemctl is-active --quiet "$SERVICE_NAME"; then
+        fail "$SERVICE_NAME did not remain active."
+        return 1
+    fi
+    if [[ "$HTTP_STATUS" != "200" && "$HTTP_STATUS" != "401" ]]; then
+        fail "Web interface on port $WEB_PORT is not ready " \
+             "(HTTP $HTTP_STATUS)."
+        return 1
+    fi
+}
+
+stop_before_restore() {
+    local stop_result=0
+
+    systemctl stop "$SERVICE_NAME" || stop_result=$?
+    if systemctl is-active --quiet "$SERVICE_NAME"; then
+        fail "$SERVICE_NAME is still active; refusing to restore files."
+        return 1
+    fi
+    if pgrep -f -- "$TARGET_DIR/Bjorn.py" >/dev/null; then
+        fail "A target Bjorn.py process remains; refusing to restore files."
+        return 1
+    fi
+    if ((stop_result != 0)); then
+        warning "systemctl stop returned $stop_result, " \
+                "but no Bjorn process remains"
+    fi
+}
+
+on_exit() {
+    local exit_code=$?
+    if ((exit_code != 0 && INSTALL_STARTED == 1)); then
+        set +e
+        error "Operation failed; stopping the attempted deployment"
+        if stop_before_restore; then
+            restore_snapshot "$ROLLBACK_DIR"
+            if start_and_verify; then
+                success "Previous files and HTTP endpoint restored"
+                printf 'Machine marker: RECOVERY_OK\n' >&2
+            else
+                error "RECOVERY_FAILED: files were restored, but the service " \
+                      "or HTTP endpoint needs attention"
+            fi
+        else
+            error "RECOVERY_ABORTED: the attempted service is still running; " \
+                  "files were not overwritten"
+        fi
+    fi
+    exit "$exit_code"
+}
+trap on_exit EXIT
+
+if [[ -n "$RESTORE_SOURCE" ]]; then
+    validate_snapshot "$RESTORE_SOURCE"
+fi
+
+success "Inputs and source files validated"
+info "Recovery snapshot: $ROLLBACK_DIR"
+
+step 2 5 "Stop the running Bjorn service"
+INSTALL_STARTED=1
+set +e
+systemctl stop "$SERVICE_NAME"
+STOP_RESULT=$?
+set -e
+
+if systemctl is-active --quiet "$SERVICE_NAME"; then
+    fail "$SERVICE_NAME is still active after stop (exit $STOP_RESULT)."
+fi
+if pgrep -f -- "$TARGET_DIR/Bjorn.py" >/dev/null; then
+    fail "A Bjorn.py process from the target directory is still running."
+fi
+if ((STOP_RESULT != 0)); then
+    warning "systemctl stop returned $STOP_RESULT, but no Bjorn process remains"
+fi
+success "$SERVICE_NAME stopped and no target process remains"
+
+if [[ -n "$RESTORE_SOURCE" ]]; then
+    step 3 5 "Restore the selected snapshot"
+    restore_snapshot "$RESTORE_SOURCE"
+    RESTORED_PYTHON_FILES=(
+        "$TARGET_DIR/actions/scanning.py"
+        "$TARGET_DIR/Bjorn.py"
+        "$TARGET_DIR/display.py"
+        "$TARGET_DIR/epd_helper.py"
+        "$TARGET_DIR/webapp.py"
+        "$TARGET_DIR/shared.py"
+    )
+    [[ -f "$TARGET_DIR/web_auth.py" ]] && \
+        RESTORED_PYTHON_FILES+=("$TARGET_DIR/web_auth.py")
+    [[ -f "$TARGET_DIR/configure_web_auth.py" ]] && \
+        RESTORED_PYTHON_FILES+=("$TARGET_DIR/configure_web_auth.py")
+    python3 -m py_compile "${RESTORED_PYTHON_FILES[@]}"
+    success "Snapshot restored and Python files compiled"
+
+    step 4 5 "Start and verify the restored service"
+    start_and_verify
+    success "$SERVICE_NAME is active; web interface returned HTTP $HTTP_STATUS"
+
+    INSTALL_STARTED=0
+    trap - EXIT
+
+    step 5 5 "Complete rollback"
+    complete "Rollback completed successfully"
+    summary_row "Service:" \
+        "$SERVICE_NAME ($(systemctl is-active "$SERVICE_NAME"))"
+    summary_row "Web interface:" "HTTP $HTTP_STATUS on port $WEB_PORT"
+    summary_row "Restored snapshot:" "$RESTORE_SOURCE"
+    summary_row "Recovery snapshot:" "$ROLLBACK_DIR"
+    printf '%bMachine marker: RESTORE_OK%b\n' "$DIM" "$NC"
+    exit 0
+fi
+
+step 3 5 "Install stability and web-auth files"
+if [[ "$SOURCE_DIR" != "$TARGET_DIR" ]]; then
+    install -m 755 -o "$TARGET_OWNER" -g "$TARGET_GROUP" \
+        "$SOURCE_DIR/actions/scanning.py" \
+        "$TARGET_DIR/actions/scanning.py"
+    install -m 755 -o "$TARGET_OWNER" -g "$TARGET_GROUP" \
+        "$SOURCE_DIR/Bjorn.py" "$TARGET_DIR/Bjorn.py"
+    install -m 755 -o "$TARGET_OWNER" -g "$TARGET_GROUP" \
+        "$SOURCE_DIR/display.py" "$TARGET_DIR/display.py"
+    install -m 755 -o "$TARGET_OWNER" -g "$TARGET_GROUP" \
+        "$SOURCE_DIR/epd_helper.py" "$TARGET_DIR/epd_helper.py"
+    install -m 755 -o "$TARGET_OWNER" -g "$TARGET_GROUP" \
+        "$SOURCE_DIR/webapp.py" "$TARGET_DIR/webapp.py"
+    install -m 755 -o "$TARGET_OWNER" -g "$TARGET_GROUP" \
+        "$SOURCE_DIR/shared.py" "$TARGET_DIR/shared.py"
+    install -m 644 -o "$TARGET_OWNER" -g "$TARGET_GROUP" \
+        "$SOURCE_DIR/web_auth.py" "$TARGET_DIR/web_auth.py"
+    install -m 755 -o "$TARGET_OWNER" -g "$TARGET_GROUP" \
+        "$SOURCE_DIR/configure_web_auth.py" \
+        "$TARGET_DIR/configure_web_auth.py"
+fi
+
+touch "$TARGET_DIR/.gitignore"
+if ! grep -qxF 'config/web_auth.json' "$TARGET_DIR/.gitignore"; then
+    printf '\nconfig/web_auth.json\n' >>"$TARGET_DIR/.gitignore"
+fi
+chown "$TARGET_OWNER:$TARGET_GROUP" "$TARGET_DIR/.gitignore"
+
+if [[ -n "$CREDENTIAL_SOURCE" ]]; then
+    TARGET_CREDENTIAL_FILE="$(readlink -m -- "$TARGET_DIR/config/web_auth.json")"
+    if [[ "$CREDENTIAL_SOURCE" != "$TARGET_CREDENTIAL_FILE" ]]; then
+        install -m 600 -o "$TARGET_OWNER" -g "$TARGET_GROUP" \
+            "$CREDENTIAL_SOURCE" "$TARGET_CREDENTIAL_FILE"
+    else
+        chmod 600 "$TARGET_CREDENTIAL_FILE"
+        chown "$TARGET_OWNER:$TARGET_GROUP" "$TARGET_CREDENTIAL_FILE"
+    fi
+elif [[ -n "$USERNAME" ]]; then
+    python3 "$TARGET_DIR/configure_web_auth.py" set "$USERNAME"
+fi
+
+if [[ -d "$COMMAND_PATH" && ! -L "$COMMAND_PATH" ]]; then
+    fail "Command path is an existing directory: $COMMAND_PATH"
+fi
+install -d -m 755 "$(dirname -- "$COMMAND_PATH")"
+ln -sfn -- "$TARGET_DIR/configure_web_auth.py" "$COMMAND_PATH"
+success "Runtime files, credentials, and management command installed"
+
+step 4 5 "Compile, start, and verify the service"
+python3 -m py_compile \
+    "$TARGET_DIR/actions/scanning.py" \
+    "$TARGET_DIR/Bjorn.py" \
+    "$TARGET_DIR/display.py" \
+    "$TARGET_DIR/epd_helper.py" \
+    "$TARGET_DIR/web_auth.py" \
+    "$TARGET_DIR/configure_web_auth.py" \
+    "$TARGET_DIR/webapp.py" \
+    "$TARGET_DIR/shared.py"
+
+start_and_verify
+success "$SERVICE_NAME is active; web interface returned HTTP $HTTP_STATUS"
+
+INSTALL_STARTED=0
+trap - EXIT
+
+step 5 5 "Complete installation"
+complete "Installation completed successfully"
+summary_row "Service:" \
+    "$SERVICE_NAME ($(systemctl is-active "$SERVICE_NAME"))"
+summary_row "Web interface:" "HTTP $HTTP_STATUS on port $WEB_PORT"
+summary_row "Rollback snapshot:" "$ROLLBACK_DIR"
+summary_row "Management command:" "$COMMAND_PATH"
+if [[ -z "$CREDENTIAL_SOURCE" && -z "$USERNAME" ]]; then
+    warning "Authentication is not configured yet"
+    info "Run: sudo http_auth set <username>"
+fi
+printf '%bMachine marker: INSTALL_OK%b\n' "$DIM" "$NC"

--- a/shared.py
+++ b/shared.py
@@ -86,6 +86,7 @@ class SharedData:
         # Files directly under configdir
         self.shared_config_json = os.path.join(self.configdir, 'shared_config.json')
         self.actions_file = os.path.join(self.configdir, 'actions.json')
+        self.web_auth_file = os.path.join(self.configdir, 'web_auth.json')
         # Files directly under resourcesdir
         self.commentsfile = os.path.join(self.commentsdir, 'comments.json')
         # Files directly under datadir

--- a/tests/run_fresh_installer_integration.sh
+++ b/tests/run_fresh_installer_integration.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+#
+# Exercise the optional fresh-install web-authentication flow end to end in an
+# isolated temporary root. No live Bjorn files or system command paths change.
+
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+TEST_ROOT="$(mktemp -d)"
+
+cleanup() {
+    rm -rf -- "$TEST_ROOT"
+}
+trap cleanup EXIT
+
+export BJORN_USER
+BJORN_USER="$(id -un)"
+export BJORN_PATH="$TEST_ROOT/Bjorn"
+export HTTP_AUTH_COMMAND_PATH="$TEST_ROOT/bin/http_auth"
+export LOG_DIR="$TEST_ROOT/log"
+export LOG_FILE="$LOG_DIR/integration.log"
+
+if python3 -c 'raise SystemExit(0)' >/dev/null 2>&1; then
+    TEST_PYTHON="$(command -v python3)"
+elif python -c 'raise SystemExit(0)' >/dev/null 2>&1; then
+    TEST_PYTHON="$(command -v python)"
+else
+    echo "FAIL: no working Python 3 interpreter found" >&2
+    exit 1
+fi
+
+mkdir -p "$BJORN_PATH/config" "$LOG_DIR" "$TEST_ROOT/python-bin"
+cat >"$TEST_ROOT/python-bin/python3" <<EOF
+#!/usr/bin/env bash
+exec "$TEST_PYTHON" "\$@"
+EOF
+chmod 755 "$TEST_ROOT/python-bin/python3"
+export PATH="$TEST_ROOT/python-bin:$PATH"
+
+cp -- "$PROJECT_DIR/configure_web_auth.py" "$BJORN_PATH/"
+cp -- "$PROJECT_DIR/web_auth.py" "$BJORN_PATH/"
+
+# Sourcing is deliberately supported so this test can exercise the exact
+# installer function without starting the full machine installer.
+# shellcheck source=../install_bjorn.sh
+source "$PROJECT_DIR/install_bjorn.sh"
+
+printf '[1/5] Decline optional tool installation\n'
+printf 'n\n' | configure_web_auth
+[[ ! -e "$HTTP_AUTH_COMMAND_PATH" && \
+   ! -L "$HTTP_AUTH_COMMAND_PATH" ]] || {
+    echo "FAIL: declining tools still created the management command" >&2
+    exit 1
+}
+
+printf '[2/5] Install the tool but defer credential setup\n'
+printf 'y\nn\n' | configure_web_auth
+if [[ -L "$HTTP_AUTH_COMMAND_PATH" ]]; then
+    [[ "$(readlink -f -- "$HTTP_AUTH_COMMAND_PATH")" == \
+       "$BJORN_PATH/configure_web_auth.py" ]] || {
+        echo "FAIL: management command points to the wrong helper" >&2
+        exit 1
+    }
+    command_layout="symlink"
+elif [[ "$OSTYPE" == msys* ]] && \
+     cmp -s -- "$HTTP_AUTH_COMMAND_PATH" \
+         "$BJORN_PATH/configure_web_auth.py"; then
+    # Git Bash copies the target when native Windows symlinks are unavailable.
+    # Linux remains strict: the Raspberry Pi must create and verify a symlink.
+    command_layout="git-bash-copy-emulation"
+    cat >"$HTTP_AUTH_COMMAND_PATH" <<EOF
+#!/usr/bin/env bash
+exec "$BJORN_PATH/configure_web_auth.py" "\$@"
+EOF
+    chmod 755 "$HTTP_AUTH_COMMAND_PATH"
+else
+    echo "FAIL: management command symlink was not created" >&2
+    exit 1
+fi
+[[ ! -e "$BJORN_PATH/config/web_auth.json" ]] || {
+    echo "FAIL: deferred setup unexpectedly created credentials" >&2
+    exit 1
+}
+
+printf '[3/5] Configure real test credentials through the installed command\n'
+TEST_PASSWORD="$(
+    "$TEST_PYTHON" -c \
+        'import secrets; print("Bjorn-test-" + secrets.token_urlsafe(24))'
+)"
+printf '%s\n' "$TEST_PASSWORD" |
+    "$HTTP_AUTH_COMMAND_PATH" set integration-user --password-stdin
+[[ -f "$BJORN_PATH/config/web_auth.json" ]] || {
+    echo "FAIL: credential file was not created" >&2
+    exit 1
+}
+credential_mode="$(stat -c '%a' -- "$BJORN_PATH/config/web_auth.json")"
+if [[ "$OSTYPE" == msys* ]]; then
+    permission_check="ntfs-mode-$credential_mode"
+elif [[ "$credential_mode" == "600" ]]; then
+    permission_check="mode-600"
+else
+    echo "FAIL: credential file mode is $credential_mode, expected 600" >&2
+    exit 1
+fi
+if grep -qF "$TEST_PASSWORD" "$BJORN_PATH/config/web_auth.json"; then
+    echo "FAIL: plaintext password was written to the credential file" >&2
+    exit 1
+fi
+
+printf '[4/5] Verify status, disable, and enable management\n'
+status_output="$("$HTTP_AUTH_COMMAND_PATH" status)"
+grep -qxF 'Credentials configured: yes' <<<"$status_output"
+grep -qxF 'Authentication enabled: yes' <<<"$status_output"
+"$HTTP_AUTH_COMMAND_PATH" disable >/dev/null
+grep -qxF 'Authentication enabled: no' \
+    <<<"$("$HTTP_AUTH_COMMAND_PATH" status)"
+"$HTTP_AUTH_COMMAND_PATH" enable >/dev/null
+grep -qxF 'Authentication enabled: yes' \
+    <<<"$("$HTTP_AUTH_COMMAND_PATH" status)"
+
+printf '[5/5] Verify the salted verifier accepts only the test password\n'
+PYTHONPATH="$BJORN_PATH" python3 - \
+    "$BJORN_PATH/config/web_auth.json" "$TEST_PASSWORD" <<'PY'
+import sys
+
+from web_auth import CredentialStore
+
+credential_file, password = sys.argv[1:]
+store = CredentialStore(credential_file)
+if not store.verify("integration-user", password):
+    raise SystemExit("FAIL: correct test credentials were rejected")
+if store.verify("integration-user", password + "-wrong"):
+    raise SystemExit("FAIL: incorrect test credentials were accepted")
+PY
+
+printf '\nFRESH_INSTALLER_INTEGRATION_OK\n'
+printf 'Management command layout: %s\n' "$command_layout"
+printf 'Credential permission check: %s\n' "$permission_check"
+printf 'Isolated root removed automatically: %s\n' "$TEST_ROOT"

--- a/tests/run_reboot_persistence_validation.sh
+++ b/tests/run_reboot_persistence_validation.sh
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+# Validate that the combined stability and web-authentication state survives a
+# real reboot. Preparation stores hashes and identifiers only, never passwords.
+
+set -Eeuo pipefail
+
+TARGET_DIR="/home/bjorn/Bjorn"
+SERVICE_NAME="bjorn.service"
+WEB_PORT=8000
+TIMEOUT=120
+THREAD_LIMIT=64
+STATE_FILE="/var/tmp/bjorn-stability-web-auth-reboot.state"
+MODE=""
+
+if [[ -t 1 && -z "${NO_COLOR:-}" ]]; then
+    GREEN=$'\033[0;32m'
+    RED=$'\033[0;31m'
+    BLUE=$'\033[0;34m'
+    NC=$'\033[0m'
+else
+    GREEN=""
+    RED=""
+    BLUE=""
+    NC=""
+fi
+
+usage() {
+    cat <<'EOF'
+Usage:
+  sudo ./tests/run_reboot_persistence_validation.sh --prepare [options]
+  sudo ./tests/run_reboot_persistence_validation.sh --verify  [options]
+
+Options:
+  --target PATH          Bjorn installation (default: /home/bjorn/Bjorn)
+  --service NAME         systemd unit (default: bjorn.service)
+  --port PORT            web port (default: 8000)
+  --timeout SECONDS      post-reboot scan timeout (default: 120)
+  --thread-limit COUNT   maximum accepted thread count (default: 64)
+  --state-file PATH      persistent hand-off file under /var/tmp
+EOF
+}
+
+fail() {
+    printf '%s[FAIL]%s %s\n' "$RED" "$NC" "$*" >&2
+    exit 1
+}
+
+success() {
+    printf '%s[OK]%s %s\n' "$GREEN" "$NC" "$*"
+}
+
+http_status() {
+    curl --silent --output /dev/null --write-out '%{http_code}' \
+        --max-time 2 "http://127.0.0.1:${WEB_PORT}/" || true
+}
+
+credential_hash() {
+    local credential_file="$TARGET_DIR/config/web_auth.json"
+    if [[ -f "$credential_file" ]]; then
+        sha256sum -- "$credential_file" | awk '{print $1}'
+    else
+        printf 'absent\n'
+    fi
+}
+
+command_target() {
+    if [[ -L /usr/local/sbin/http_auth ]]; then
+        readlink -f -- /usr/local/sbin/http_auth
+    elif [[ -e /usr/local/sbin/http_auth ]]; then
+        printf 'regular-file\n'
+    else
+        printf 'absent\n'
+    fi
+}
+
+while (($#)); do
+    case "$1" in
+        --prepare|--verify)
+            [[ -z "$MODE" ]] || fail "choose only one mode"
+            MODE="${1#--}"
+            shift
+            ;;
+        --target)
+            TARGET_DIR="$2"
+            shift 2
+            ;;
+        --service)
+            SERVICE_NAME="$2"
+            shift 2
+            ;;
+        --port)
+            WEB_PORT="$2"
+            shift 2
+            ;;
+        --timeout)
+            TIMEOUT="$2"
+            shift 2
+            ;;
+        --thread-limit)
+            THREAD_LIMIT="$2"
+            shift 2
+            ;;
+        --state-file)
+            STATE_FILE="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            fail "unknown argument: $1"
+            ;;
+    esac
+done
+
+[[ $EUID -eq 0 ]] || fail "run this validation with sudo"
+[[ "$MODE" == "prepare" || "$MODE" == "verify" ]] || {
+    usage
+    exit 2
+}
+[[ "$TIMEOUT" =~ ^[1-9][0-9]*$ ]] || fail "timeout must be positive"
+[[ "$THREAD_LIMIT" =~ ^[1-9][0-9]*$ ]] || \
+    fail "thread limit must be positive"
+
+prepare() {
+    local current_http
+    local current_boot
+    local current_hash
+    local current_command
+
+    systemctl is-active --quiet "$SERVICE_NAME" || \
+        fail "$SERVICE_NAME is not active"
+    current_http="$(http_status)"
+    [[ "$current_http" == "200" || "$current_http" == "401" ]] || \
+        fail "web interface returned HTTP $current_http"
+    current_boot="$(cat /proc/sys/kernel/random/boot_id)"
+    current_hash="$(credential_hash)"
+    current_command="$(command_target)"
+
+    umask 077
+    {
+        printf 'OLD_BOOT_ID=%q\n' "$current_boot"
+        printf 'EXPECTED_HTTP=%q\n' "$current_http"
+        printf 'CREDENTIAL_HASH=%q\n' "$current_hash"
+        printf 'COMMAND_TARGET=%q\n' "$current_command"
+        printf 'TARGET_DIR=%q\n' "$TARGET_DIR"
+        printf 'SERVICE_NAME=%q\n' "$SERVICE_NAME"
+        printf 'WEB_PORT=%q\n' "$WEB_PORT"
+    } >"$STATE_FILE"
+    chmod 600 "$STATE_FILE"
+
+    printf '\n%sBjorn reboot-persistence validation%s\n' "$BLUE" "$NC"
+    success "Pre-reboot service and HTTP state captured"
+    printf '     Boot ID: %s\n' "$current_boot"
+    printf '     HTTP: %s, credentials: %s, command: %s\n' \
+        "$current_http" "$current_hash" "$current_command"
+    printf '\nMachine marker: REBOOT_PERSISTENCE_PREPARED\n'
+    printf 'Next: sudo reboot\n'
+}
+
+verify() {
+    local old_boot_id
+    local expected_http
+    local expected_hash
+    local expected_command
+    local new_boot_id
+    local pid=""
+    local initial_pid=""
+    local current_http="000"
+    local completed_scans=0
+    local threads=0
+    local max_threads=0
+    local elapsed=0
+    local journal_output
+
+    [[ -f "$STATE_FILE" ]] || fail "preparation state is missing: $STATE_FILE"
+    # The state is root-owned mode 0600 and contains shell-escaped scalar data.
+    # shellcheck disable=SC1090
+    source "$STATE_FILE"
+    old_boot_id="$OLD_BOOT_ID"
+    expected_http="$EXPECTED_HTTP"
+    expected_hash="$CREDENTIAL_HASH"
+    expected_command="$COMMAND_TARGET"
+    new_boot_id="$(cat /proc/sys/kernel/random/boot_id)"
+
+    [[ "$new_boot_id" != "$old_boot_id" ]] || \
+        fail "boot ID did not change; a real reboot was not observed"
+
+    printf '\n%sBjorn reboot-persistence validation%s\n' "$BLUE" "$NC"
+    printf 'Waiting for service, HTTP, and one completed scan...\n'
+
+    while ((elapsed <= TIMEOUT)); do
+        if systemctl is-active --quiet "$SERVICE_NAME"; then
+            pid="$(systemctl show "$SERVICE_NAME" -p MainPID --value)"
+            if [[ "$pid" =~ ^[1-9][0-9]*$ ]]; then
+                [[ -n "$initial_pid" ]] || initial_pid="$pid"
+                [[ "$pid" == "$initial_pid" ]] || \
+                    fail "service PID changed during verification"
+                current_http="$(http_status)"
+                threads="$(ps -o nlwp= -p "$pid" | tr -d ' ' || true)"
+                [[ "$threads" =~ ^[0-9]+$ ]] || threads=0
+                ((threads > max_threads)) && max_threads="$threads"
+                completed_scans="$({
+                    journalctl -b _PID="$pid" --no-pager -o cat 2>/dev/null || true
+                } | grep -cF 'Scan results cleaned up' || true)"
+            fi
+        fi
+
+        printf '\rPost-reboot: %3d/%ds | HTTP %s | Threads %d | Scans %d' \
+            "$elapsed" "$TIMEOUT" "$current_http" "$threads" \
+            "$completed_scans"
+
+        if [[ "$current_http" == "$expected_http" ]] && \
+           ((completed_scans >= 1)); then
+            break
+        fi
+        sleep 5
+        ((elapsed += 5))
+    done
+    printf '\n'
+
+    systemctl is-active --quiet "$SERVICE_NAME" || \
+        fail "$SERVICE_NAME is not active after reboot"
+    [[ "$current_http" == "$expected_http" ]] || \
+        fail "HTTP changed from $expected_http to $current_http"
+    ((completed_scans >= 1)) || fail "no completed scan after reboot"
+    ((max_threads <= THREAD_LIMIT)) || \
+        fail "thread peak $max_threads exceeds limit $THREAD_LIMIT"
+    [[ "$(credential_hash)" == "$expected_hash" ]] || \
+        fail "credential file changed across reboot"
+    [[ "$(command_target)" == "$expected_command" ]] || \
+        fail "http_auth command target changed across reboot"
+
+    journal_output="$(journalctl -b _PID="$pid" --no-pager -o cat || true)"
+    if grep -qiE \
+        'cannot schedule new|can.t start new thread|pthread_create|fatal python error|error in scan|traceback' \
+        <<<"$journal_output"; then
+        grep -iE \
+            'cannot schedule new|can.t start new thread|pthread_create|fatal python error|error in scan|traceback' \
+            <<<"$journal_output" >&2
+        fail "runtime errors found in the post-reboot journal"
+    fi
+
+    success "A real reboot was observed"
+    success "Service, HTTP authentication, credentials, and command persisted"
+    success "A scan completed without runtime errors"
+    printf '     PID %s, HTTP %s, peak %d threads, %d completed scan(s)\n' \
+        "$pid" "$current_http" "$max_threads" "$completed_scans"
+    printf '\n%s[PASS]%s Reboot persistence validation completed successfully.\n' \
+        "$GREEN" "$NC"
+    printf 'Machine marker: REBOOT_PERSISTENCE_VALIDATION_OK\n'
+    rm -f -- "$STATE_FILE"
+}
+
+case "$MODE" in
+    prepare) prepare ;;
+    verify) verify ;;
+esac

--- a/tests/run_scan_worker_validation.sh
+++ b/tests/run_scan_worker_validation.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+#
+# Run Bjorn scan-worker checks at unit and/or live-runtime level.
+
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+TARGET_DIR="/home/bjorn/Bjorn"
+SERVICE_NAME="bjorn.service"
+WEB_PORT=8000
+DURATION=30
+SCAN_TIMEOUT=90
+THREAD_LIMIT=64
+EXPECTED_HTTP="auto"
+RUN_LEVEL="all"
+
+usage() {
+    cat <<'EOF'
+Usage:
+  ./tests/run_scan_worker_validation.sh --unit
+  sudo ./tests/run_scan_worker_validation.sh --runtime [options]
+  sudo ./tests/run_scan_worker_validation.sh --all [options]
+
+Levels:
+  --unit              Syntax, compile, and Python unit tests only
+  --runtime           Installed-file, stability, and lifecycle tests only
+  --all               Unit plus runtime tests (default)
+
+Runtime options:
+  --target PATH       Live Bjorn directory (default: /home/bjorn/Bjorn)
+  --service UNIT      Systemd service (default: bjorn.service)
+  --port PORT         Expected web port (default: 8000)
+  --duration SEC      Stability observation time (default: 30)
+  --scan-timeout SEC  Maximum time from test start for one scan (default: 90)
+  --thread-limit N    Maximum allowed process threads (default: 64)
+  --expect-http CODE  auto, 200, or 401 (default: auto)
+  -h, --help          Show this help
+EOF
+}
+
+fail() {
+    echo "VALIDATION_FAIL: $*" >&2
+    exit 1
+}
+
+require_value() {
+    local option="$1"
+    local value="${2:-}"
+    [[ -n "$value" ]] || fail "$option requires a value"
+}
+
+while (($#)); do
+    case "$1" in
+        --unit|--runtime|--all)
+            RUN_LEVEL="${1#--}"
+            shift
+            ;;
+        --target)
+            require_value "$1" "${2:-}"
+            TARGET_DIR="$2"
+            shift 2
+            ;;
+        --service)
+            require_value "$1" "${2:-}"
+            SERVICE_NAME="$2"
+            shift 2
+            ;;
+        --port)
+            require_value "$1" "${2:-}"
+            WEB_PORT="$2"
+            shift 2
+            ;;
+        --duration)
+            require_value "$1" "${2:-}"
+            DURATION="$2"
+            shift 2
+            ;;
+        --scan-timeout)
+            require_value "$1" "${2:-}"
+            SCAN_TIMEOUT="$2"
+            shift 2
+            ;;
+        --thread-limit)
+            require_value "$1" "${2:-}"
+            THREAD_LIMIT="$2"
+            shift 2
+            ;;
+        --expect-http)
+            require_value "$1" "${2:-}"
+            EXPECTED_HTTP="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            fail "unknown option: $1"
+            ;;
+    esac
+done
+
+run_unit_tests() {
+    echo "== Unit level =="
+    bash -n "$PROJECT_DIR/install_stability_web_auth.sh"
+    bash -n "$SCRIPT_DIR/validate_scan_runtime.sh"
+    bash -n "$SCRIPT_DIR/validate_scan_lifecycle.sh"
+    bash -n "$SCRIPT_DIR/run_scan_worker_validation.sh"
+    python3 -m py_compile \
+        "$PROJECT_DIR/actions/scanning.py" \
+        "$PROJECT_DIR/Bjorn.py" \
+        "$PROJECT_DIR/display.py" \
+        "$PROJECT_DIR/epd_helper.py" \
+        "$PROJECT_DIR/webapp.py"
+    (
+        cd "$PROJECT_DIR"
+        python3 -m unittest discover -s tests -p 'test_*.py' -v
+    )
+    echo "UNIT_LEVEL_OK"
+}
+
+verify_webapp_lifecycle_contract() {
+    local webapp="$TARGET_DIR/webapp.py"
+
+    [[ -f "$webapp" ]] || \
+        fail "live webapp.py is missing"
+
+    grep -Eq \
+        'allow_reuse_address[[:space:]]*=[[:space:]]*True' \
+        "$webapp" || \
+        fail "live webapp.py is missing reusable-port support"
+    grep -Eq \
+        'httpd\.timeout[[:space:]]*=[[:space:]]*0\.5' \
+        "$webapp" || \
+        fail "live webapp.py is missing the bounded request timeout"
+    grep -Eq \
+        'super\(\)\.__init__\(name="BjornWeb"\)' \
+        "$webapp" || \
+        fail "live webapp.py is missing the named non-daemon web thread"
+    grep -Fq \
+        'Unexpected web server thread error ' \
+        "$webapp" || \
+        fail "live webapp.py is missing controlled thread-error handling"
+
+    if cmp -s "$PROJECT_DIR/webapp.py" "$webapp"; then
+        echo "WEBAPP_LIFECYCLE_EXACT_MATCH"
+    else
+        echo "WEBAPP_LIFECYCLE_COMPATIBLE_LAYER"
+    fi
+}
+
+run_runtime_tests() {
+    echo "== Runtime level =="
+    [[ $EUID -eq 0 ]] || \
+        fail "run runtime/all validation with sudo"
+
+    TARGET_DIR="$(readlink -f -- "$TARGET_DIR")"
+    cmp -s "$PROJECT_DIR/Bjorn.py" "$TARGET_DIR/Bjorn.py" || \
+        fail "live Bjorn.py does not match the tested contribution"
+    cmp -s \
+        "$PROJECT_DIR/actions/scanning.py" \
+        "$TARGET_DIR/actions/scanning.py" || \
+        fail "live actions/scanning.py does not match the tested contribution"
+    cmp -s "$PROJECT_DIR/display.py" "$TARGET_DIR/display.py" || \
+        fail "live display.py does not match the tested contribution"
+    cmp -s "$PROJECT_DIR/epd_helper.py" "$TARGET_DIR/epd_helper.py" || \
+        fail "live epd_helper.py does not match the tested contribution"
+    verify_webapp_lifecycle_contract
+    echo "INSTALLED_FILES_MATCH"
+
+    "$SCRIPT_DIR/validate_scan_runtime.sh" \
+        --service "$SERVICE_NAME" \
+        --port "$WEB_PORT" \
+        --duration "$DURATION" \
+        --scan-timeout "$SCAN_TIMEOUT" \
+        --thread-limit "$THREAD_LIMIT" \
+        --expect-http "$EXPECTED_HTTP"
+
+    "$SCRIPT_DIR/validate_scan_lifecycle.sh" \
+        --service "$SERVICE_NAME" \
+        --target "$TARGET_DIR" \
+        --port "$WEB_PORT" \
+        --expect-http "$EXPECTED_HTTP"
+
+    echo "RUNTIME_LEVEL_OK"
+}
+
+case "$RUN_LEVEL" in
+    unit)
+        run_unit_tests
+        ;;
+    runtime)
+        run_runtime_tests
+        ;;
+    all)
+        run_unit_tests
+        run_runtime_tests
+        ;;
+    *)
+        fail "unsupported validation level: $RUN_LEVEL"
+        ;;
+esac
+
+echo "SCAN_WORKER_VALIDATION_OK level=$RUN_LEVEL"

--- a/tests/run_stability_web_auth_validation.sh
+++ b/tests/run_stability_web_auth_validation.sh
@@ -252,6 +252,8 @@ run_captured() {
 }
 
 run_static_checks() {
+    "$PYTHON_BIN" -c 'import pandas'
+
     bash -n "$PROJECT_DIR/install_bjorn.sh"
     bash -n "$PROJECT_DIR/install_stability_web_auth.sh"
     bash -n "$SCRIPT_DIR/run_fresh_installer_integration.sh"

--- a/tests/run_stability_web_auth_validation.sh
+++ b/tests/run_stability_web_auth_validation.sh
@@ -1,0 +1,394 @@
+#!/usr/bin/env bash
+#
+# Run the complete Bjorn stability and optional web-auth contribution checks.
+
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+TARGET_DIR="/home/bjorn/Bjorn"
+SERVICE_NAME="bjorn.service"
+COMMAND_PATH="/usr/local/sbin/http_auth"
+WEB_PORT=8000
+DURATION=30
+SCAN_TIMEOUT=90
+THREAD_LIMIT=64
+RUN_LEVEL="all"
+VERBOSE=false
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+UNIT_SECTION_LABEL="[1/3]"
+SCAN_SECTION_LABEL="[2/3]"
+AUTH_SECTION_LABEL="[3/3]"
+ACTIVE_CHILD_PID=""
+LAST_RUN_LOG=""
+LAST_RUN_SECONDS=0
+TEMP_LOGS=()
+
+if [[ -t 1 && -z "${NO_COLOR:-}" ]]; then
+    COLOR_ENABLED=true
+    RESET=$'\033[0m'
+    BOLD=$'\033[1m'
+    DIM=$'\033[2m'
+    RED=$'\033[31m'
+    GREEN=$'\033[32m'
+    YELLOW=$'\033[33m'
+    CYAN=$'\033[36m'
+else
+    COLOR_ENABLED=false
+    RESET=""
+    BOLD=""
+    DIM=""
+    RED=""
+    GREEN=""
+    YELLOW=""
+    CYAN=""
+fi
+
+usage() {
+    cat <<'EOF'
+Usage:
+  ./tests/run_stability_web_auth_validation.sh --unit
+  sudo ./tests/run_stability_web_auth_validation.sh --runtime [options]
+  sudo ./tests/run_stability_web_auth_validation.sh --all [options]
+
+Levels:
+  --unit              Syntax, compile, and all Python tests
+  --runtime           Scanner/lifecycle followed by live web-auth validation
+  --all               Unit plus runtime validation (default)
+
+Runtime options:
+  --target PATH       Live Bjorn directory (default: /home/bjorn/Bjorn)
+  --service UNIT      Systemd service (default: bjorn.service)
+  --command PATH      Web-auth command (default: /usr/local/sbin/http_auth)
+  --port PORT         Web port (default: 8000)
+  --duration SEC      Scanner observation time (default: 30)
+  --scan-timeout SEC  Maximum time for one scan (default: 90)
+  --thread-limit N    Maximum process threads (default: 64)
+  --verbose           Show complete output from every underlying test
+  -h, --help          Show this help
+
+Colors are enabled automatically on an interactive terminal. Set NO_COLOR=1
+to disable them. Set PYTHON_BIN to override the Python executable used by the
+unit level (default: python3).
+EOF
+}
+
+fail() {
+    printf '%s[FAIL]%s %s\n' "$RED$BOLD" "$RESET" "$*" >&2
+    exit 1
+}
+
+require_value() {
+    local option="$1"
+    local value="${2:-}"
+    [[ -n "$value" ]] || fail "$option requires a value"
+}
+
+while (($#)); do
+    case "$1" in
+        --unit|--runtime|--all)
+            RUN_LEVEL="${1#--}"
+            shift
+            ;;
+        --target)
+            require_value "$1" "${2:-}"
+            TARGET_DIR="$2"
+            shift 2
+            ;;
+        --service)
+            require_value "$1" "${2:-}"
+            SERVICE_NAME="$2"
+            shift 2
+            ;;
+        --command)
+            require_value "$1" "${2:-}"
+            COMMAND_PATH="$2"
+            shift 2
+            ;;
+        --port)
+            require_value "$1" "${2:-}"
+            WEB_PORT="$2"
+            shift 2
+            ;;
+        --duration)
+            require_value "$1" "${2:-}"
+            DURATION="$2"
+            shift 2
+            ;;
+        --scan-timeout)
+            require_value "$1" "${2:-}"
+            SCAN_TIMEOUT="$2"
+            shift 2
+            ;;
+        --thread-limit)
+            require_value "$1" "${2:-}"
+            THREAD_LIMIT="$2"
+            shift 2
+            ;;
+        --verbose)
+            VERBOSE=true
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            fail "unknown option: $1"
+            ;;
+    esac
+done
+
+case "$RUN_LEVEL" in
+    unit)
+        UNIT_SECTION_LABEL="[1/1]"
+        ;;
+    runtime)
+        SCAN_SECTION_LABEL="[1/2]"
+        AUTH_SECTION_LABEL="[2/2]"
+        ;;
+esac
+
+cleanup() {
+    local log_file
+    if [[ -n "$ACTIVE_CHILD_PID" ]] && \
+       kill -0 "$ACTIVE_CHILD_PID" 2>/dev/null; then
+        kill -TERM "$ACTIVE_CHILD_PID" 2>/dev/null || true
+        wait "$ACTIVE_CHILD_PID" 2>/dev/null || true
+    fi
+    for log_file in "${TEMP_LOGS[@]}"; do
+        rm -f -- "$log_file"
+    done
+}
+
+handle_interrupt() {
+    printf '\n%s[STOP]%s Validation interrupted; cleaning up...\n' \
+        "$YELLOW$BOLD" "$RESET" >&2
+    exit 130
+}
+
+trap cleanup EXIT
+trap handle_interrupt INT TERM
+
+banner() {
+    printf '\n%s%sBjorn stability and web-auth validation%s\n' \
+        "$BOLD" "$CYAN" "$RESET"
+    printf '%sTarget:%s  %s\n' "$DIM" "$RESET" "$TARGET_DIR"
+    printf '%sMode:%s    %s\n\n' "$DIM" "$RESET" "$RUN_LEVEL"
+}
+
+section() {
+    printf '%s%s%s%s\n' "$BOLD" "$CYAN" "$*" "$RESET"
+}
+
+success() {
+    printf '  %s[OK]%s %s\n' "$GREEN$BOLD" "$RESET" "$*"
+}
+
+detail() {
+    printf '       %s%s%s\n' "$DIM" "$*" "$RESET"
+}
+
+log_value() {
+    local log_file="$1"
+    local marker="$2"
+    local key="$3"
+    grep -E "^${marker}( |$)" "$log_file" |
+        tail -1 |
+        sed -n "s/.*${key}=\\([^ ]*\\).*/\\1/p"
+}
+
+run_captured() {
+    local label="$1"
+    shift
+    local log_file
+    local started
+    local elapsed
+    local status
+
+    log_file="$(mktemp)"
+    TEMP_LOGS+=("$log_file")
+    started=$SECONDS
+
+    if [[ "$VERBOSE" == true ]]; then
+        printf '  %s...%s %s\n' "$CYAN" "$RESET" "$label"
+        set +e
+        "$@" 2>&1 | tee "$log_file"
+        status=${PIPESTATUS[0]}
+        set -e
+    else
+        "$@" >"$log_file" 2>&1 &
+        ACTIVE_CHILD_PID=$!
+        if [[ "$COLOR_ENABLED" == true ]]; then
+            while kill -0 "$ACTIVE_CHILD_PID" 2>/dev/null; do
+                elapsed=$((SECONDS - started))
+                printf '\r\033[2K  %s[...]%s %s (%ss)' \
+                    "$CYAN$BOLD" "$RESET" "$label" "$elapsed"
+                sleep 1
+            done
+            printf '\r\033[2K'
+        else
+            printf '  [...] %s\n' "$label"
+        fi
+        set +e
+        wait "$ACTIVE_CHILD_PID"
+        status=$?
+        set -e
+        ACTIVE_CHILD_PID=""
+    fi
+
+    LAST_RUN_SECONDS=$((SECONDS - started))
+    LAST_RUN_LOG="$log_file"
+    if ((status != 0)); then
+        printf '  %s[FAIL]%s %s\n' "$RED$BOLD" "$RESET" "$label" >&2
+        printf '\n%s--- complete diagnostic output ---%s\n' \
+            "$YELLOW" "$RESET" >&2
+        cat "$log_file" >&2
+        printf '%s--- end diagnostic output ---%s\n\n' \
+            "$YELLOW" "$RESET" >&2
+        return "$status"
+    fi
+    return 0
+}
+
+run_static_checks() {
+    bash -n "$PROJECT_DIR/install_bjorn.sh"
+    bash -n "$PROJECT_DIR/install_stability_web_auth.sh"
+    bash -n "$SCRIPT_DIR/run_fresh_installer_integration.sh"
+    bash -n "$SCRIPT_DIR/run_stability_web_auth_validation.sh"
+    bash -n "$SCRIPT_DIR/run_scan_worker_validation.sh"
+    bash -n "$SCRIPT_DIR/run_web_auth_validation.sh"
+    bash -n "$SCRIPT_DIR/run_reboot_persistence_validation.sh"
+    bash -n "$SCRIPT_DIR/validate_scan_runtime.sh"
+    bash -n "$SCRIPT_DIR/validate_scan_lifecycle.sh"
+    bash -n "$SCRIPT_DIR/validate_web_auth_runtime.sh"
+
+    "$PYTHON_BIN" -m py_compile \
+        "$PROJECT_DIR/actions/scanning.py" \
+        "$PROJECT_DIR/Bjorn.py" \
+        "$PROJECT_DIR/display.py" \
+        "$PROJECT_DIR/epd_helper.py" \
+        "$PROJECT_DIR/webapp.py" \
+        "$PROJECT_DIR/shared.py" \
+        "$PROJECT_DIR/web_auth.py" \
+        "$PROJECT_DIR/configure_web_auth.py"
+}
+
+run_python_tests() {
+    cd "$PROJECT_DIR"
+    "$PYTHON_BIN" -m unittest discover -s tests -p 'test_*.py' -v
+}
+
+run_unit_tests() {
+    local test_summary
+
+    section "$UNIT_SECTION_LABEL Source and automated tests"
+    run_captured "Checking shell and Python syntax" run_static_checks ||
+        fail "static checks failed"
+    success "Shell syntax and Python compilation"
+
+    run_captured "Running unit and integration tests" run_python_tests ||
+        fail "unit or integration tests failed"
+    test_summary="$(
+        grep -E '^Ran [0-9]+ tests? in [0-9.]+s$' "$LAST_RUN_LOG" |
+            tail -1 || true
+    )"
+    success "${test_summary:-All unit and integration tests passed}"
+    detail "Lifecycle, scanner, display/GPIO, credentials, and every web route"
+
+    run_captured "Testing the isolated fresh-installer choices" \
+        "$SCRIPT_DIR/run_fresh_installer_integration.sh" ||
+        fail "fresh-installer integration test failed"
+    success "Fresh-installer decline, install, credentials, and management flow"
+}
+
+run_runtime_tests() {
+    local scan_pid
+    local scan_http
+    local max_threads
+    local completed_scans
+    local stop_duration
+    local new_pid
+    local challenge_requests
+    local post_elapsed
+    local invalid_warnings
+
+    [[ $EUID -eq 0 ]] || \
+        fail "run runtime/all validation with sudo"
+
+    section "$SCAN_SECTION_LABEL Live scanner and service lifecycle"
+    run_captured "Observing a complete scan and service restart" \
+        "$SCRIPT_DIR/run_scan_worker_validation.sh" \
+        --runtime \
+        --target "$TARGET_DIR" \
+        --service "$SERVICE_NAME" \
+        --port "$WEB_PORT" \
+        --duration "$DURATION" \
+        --scan-timeout "$SCAN_TIMEOUT" \
+        --thread-limit "$THREAD_LIMIT" \
+        --expect-http 401 ||
+        fail "live scanner or service lifecycle validation failed"
+
+    scan_pid="$(log_value "$LAST_RUN_LOG" RUNTIME_OK PID)"
+    scan_http="$(log_value "$LAST_RUN_LOG" RUNTIME_OK HTTP)"
+    max_threads="$(log_value "$LAST_RUN_LOG" RUNTIME_OK MAX_THREADS)"
+    completed_scans="$(
+        log_value "$LAST_RUN_LOG" RUNTIME_OK COMPLETED_SCANS
+    )"
+    stop_duration="$(
+        log_value "$LAST_RUN_LOG" LIFECYCLE_OK STOP_DURATION
+    )"
+    new_pid="$(log_value "$LAST_RUN_LOG" LIFECYCLE_OK NEW_PID)"
+    success "Scanner completed without worker or executor errors"
+    local scan_label="scans"
+    [[ "${completed_scans:-0}" == "1" ]] && scan_label="scan"
+    detail "PID ${scan_pid:-?}, HTTP ${scan_http:-?}, peak ${max_threads:-?} threads, ${completed_scans:-?} completed $scan_label"
+    success "Service stopped cleanly and returned on port $WEB_PORT"
+    detail "Stop ${stop_duration:-?}, restarted as PID ${new_pid:-?}"
+
+    section "$AUTH_SECTION_LABEL Live web authentication"
+    run_captured "Checking commands, routes, and malformed requests" \
+        "$SCRIPT_DIR/run_web_auth_validation.sh" \
+        --runtime \
+        --target "$TARGET_DIR" \
+        --service "$SERVICE_NAME" \
+        --command "$COMMAND_PATH" \
+        --port "$WEB_PORT" ||
+        fail "live web-authentication validation failed"
+
+    challenge_requests="$(
+        log_value "$LAST_RUN_LOG" HEADERLESS_CHALLENGE_STRESS_OK requests
+    )"
+    post_elapsed="$(
+        log_value "$LAST_RUN_LOG" INCOMPLETE_POST_OK elapsed
+    )"
+    invalid_warnings="$(
+        log_value "$LAST_RUN_LOG" JOURNAL_AUDIT_OK invalid_warnings
+    )"
+    success "Management commands and every HTTP route are protected"
+    success "${challenge_requests:-30} browser challenges completed"
+    detail "Incomplete POST rejected in ${post_elapsed:-?}; audit warnings observed: ${invalid_warnings:-?}"
+    success "Original credential state restored"
+}
+
+banner
+case "$RUN_LEVEL" in
+    unit)
+        run_unit_tests
+        ;;
+    runtime)
+        run_runtime_tests
+        ;;
+    all)
+        run_unit_tests
+        run_runtime_tests
+        ;;
+    *)
+        fail "unsupported validation level: $RUN_LEVEL"
+        ;;
+esac
+
+printf '\n%s%s[PASS] All requested validation levels completed successfully.%s\n' \
+    "$GREEN" "$BOLD" "$RESET"
+printf '%sMachine marker:%s STABILITY_WEB_AUTH_VALIDATION_OK level=%s\n\n' \
+    "$DIM" "$RESET" "$RUN_LEVEL"

--- a/tests/run_web_auth_validation.sh
+++ b/tests/run_web_auth_validation.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+#
+# Run Bjorn web-auth checks at unit and/or live-runtime level.
+
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+TARGET_DIR="/home/bjorn/Bjorn"
+SERVICE_NAME="bjorn.service"
+COMMAND_PATH="/usr/local/sbin/http_auth"
+WEB_PORT=8000
+RUN_LEVEL="all"
+
+usage() {
+    cat <<'EOF'
+Usage:
+  ./tests/run_web_auth_validation.sh --unit
+  sudo ./tests/run_web_auth_validation.sh --runtime [options]
+  sudo ./tests/run_web_auth_validation.sh --all [options]
+
+Levels:
+  --unit              Syntax, compile, and Python tests only
+  --runtime           Installed-file and live HTTP/command tests only
+  --all               Unit plus runtime tests (default)
+
+Runtime options:
+  --target PATH       Live Bjorn directory (default: /home/bjorn/Bjorn)
+  --service UNIT      Systemd service (default: bjorn.service)
+  --command PATH      Management command (default: /usr/local/sbin/http_auth)
+  --port PORT         Web port (default: 8000)
+  -h, --help          Show this help
+EOF
+}
+
+fail() {
+    echo "WEB_AUTH_VALIDATION_FAIL: $*" >&2
+    exit 1
+}
+
+require_value() {
+    local option="$1"
+    local value="${2:-}"
+    [[ -n "$value" ]] || fail "$option requires a value"
+}
+
+while (($#)); do
+    case "$1" in
+        --unit|--runtime|--all)
+            RUN_LEVEL="${1#--}"
+            shift
+            ;;
+        --target)
+            require_value "$1" "${2:-}"
+            TARGET_DIR="$2"
+            shift 2
+            ;;
+        --service)
+            require_value "$1" "${2:-}"
+            SERVICE_NAME="$2"
+            shift 2
+            ;;
+        --command)
+            require_value "$1" "${2:-}"
+            COMMAND_PATH="$2"
+            shift 2
+            ;;
+        --port)
+            require_value "$1" "${2:-}"
+            WEB_PORT="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            fail "unknown option: $1"
+            ;;
+    esac
+done
+
+run_unit_tests() {
+    echo "== Unit level =="
+    bash -n "$PROJECT_DIR/install_stability_web_auth.sh"
+    bash -n "$SCRIPT_DIR/validate_web_auth_runtime.sh"
+    bash -n "$SCRIPT_DIR/run_web_auth_validation.sh"
+    python3 -m py_compile \
+        "$PROJECT_DIR/web_auth.py" \
+        "$PROJECT_DIR/configure_web_auth.py" \
+        "$PROJECT_DIR/webapp.py" \
+        "$PROJECT_DIR/shared.py"
+    (
+        cd "$PROJECT_DIR"
+        python3 -m unittest discover -s tests -p 'test_*.py' -v
+    )
+    echo "UNIT_LEVEL_OK"
+}
+
+run_runtime_tests() {
+    local resolved_command
+
+    echo "== Runtime level =="
+    [[ $EUID -eq 0 ]] || \
+        fail "run runtime/all validation with sudo"
+    TARGET_DIR="$(readlink -f -- "$TARGET_DIR")"
+
+    for relative_path in \
+        web_auth.py \
+        configure_web_auth.py \
+        webapp.py \
+        shared.py; do
+        cmp -s \
+            "$PROJECT_DIR/$relative_path" \
+            "$TARGET_DIR/$relative_path" || \
+            fail "live $relative_path does not match the tested contribution"
+    done
+
+    [[ -e "$COMMAND_PATH" ]] || \
+        fail "management command not found: $COMMAND_PATH"
+    resolved_command="$(readlink -f -- "$COMMAND_PATH")"
+    [[ "$resolved_command" == "$TARGET_DIR/configure_web_auth.py" ]] || \
+        fail "management command points to unexpected file: $resolved_command"
+    echo "INSTALLED_FILES_MATCH"
+
+    "$SCRIPT_DIR/validate_web_auth_runtime.sh" \
+        --target "$TARGET_DIR" \
+        --service "$SERVICE_NAME" \
+        --command "$COMMAND_PATH" \
+        --port "$WEB_PORT"
+
+    echo "RUNTIME_LEVEL_OK"
+}
+
+case "$RUN_LEVEL" in
+    unit)
+        run_unit_tests
+        ;;
+    runtime)
+        run_runtime_tests
+        ;;
+    all)
+        run_unit_tests
+        run_runtime_tests
+        ;;
+    *)
+        fail "unsupported validation level: $RUN_LEVEL"
+        ;;
+esac
+
+echo "WEB_AUTH_VALIDATION_OK level=$RUN_LEVEL"

--- a/tests/test_bjorn_lifecycle.py
+++ b/tests/test_bjorn_lifecycle.py
@@ -180,6 +180,42 @@ class BjornLifecycleTests(unittest.TestCase):
 
         self.assertEqual(alive_names, ["StuckWorker"])
 
+    def test_shutdown_wait_shares_one_deadline_across_all_threads(self):
+        clock = SimpleNamespace(now=0.0)
+
+        class BlockingThread(FakeThread):
+            def is_alive(self):
+                return True
+
+            def join(self, timeout=None):
+                self.join_timeouts.append(timeout)
+                clock.now += timeout + 0.000001
+
+        stuck_threads = [
+            BlockingThread(name=f"StuckWorker{index}")
+            for index in range(6)
+        ]
+
+        with patch.object(
+            self.bjorn_module.time,
+            "monotonic",
+            side_effect=lambda: clock.now,
+        ):
+            alive_names = self.bjorn_module.wait_for_shutdown_threads(
+                stuck_threads,
+                timeout=0.05,
+            )
+
+        allocated_wait = sum(
+            sum(thread.join_timeouts)
+            for thread in stuck_threads
+        )
+        self.assertLessEqual(allocated_wait, 0.05)
+        self.assertEqual(
+            alive_names,
+            [thread.name for thread in stuck_threads],
+        )
+
     def test_shutdown_wait_reports_a_thread_with_custom_join_failure(self):
         gpio_thread = FakeThread(
             name="GPIOHold",

--- a/tests/test_bjorn_lifecycle.py
+++ b/tests/test_bjorn_lifecycle.py
@@ -1,0 +1,272 @@
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+class NullLogger:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def info(self, _message):
+        pass
+
+    def error(self, _message):
+        pass
+
+    def warning(self, _message):
+        pass
+
+
+class FakeThread:
+    def __init__(
+        self,
+        alive_checks=1,
+        name="FakeThread",
+        join_error=None,
+    ):
+        self.alive_checks = alive_checks
+        self.name = name
+        self.join_timeouts = []
+        self.join_error = join_error
+
+    def is_alive(self):
+        return len(self.join_timeouts) < self.alive_checks
+
+    def join(self, timeout=None):
+        self.join_timeouts.append(timeout)
+        if self.join_error is not None:
+            raise self.join_error
+
+
+class FakeDisplay:
+    def __init__(self):
+        self.stop_requested = False
+        self.hardware_closed = False
+        self.workers = [
+            FakeThread(name="DisplayImage"),
+            FakeThread(name="DisplaySharedData"),
+            FakeThread(name="DisplayVulnerabilityCount"),
+        ]
+
+    def request_stop(self):
+        self.stop_requested = True
+
+    def background_threads(self):
+        return self.workers
+
+    def close_hardware(self):
+        self.hardware_closed = True
+
+
+class BjornLifecycleTests(unittest.TestCase):
+    MODULE_NAME = "_bjorn_lifecycle_under_test"
+
+    @classmethod
+    def setUpClass(cls):
+        cls.shared_data = SimpleNamespace(
+            should_exit=False,
+            orchestrator_should_exit=False,
+            display_should_exit=False,
+            webapp_should_exit=False,
+        )
+
+        init_shared = types.ModuleType("init_shared")
+        init_shared.shared_data = cls.shared_data
+        display = types.ModuleType("display")
+        display.Display = object
+        comment = types.ModuleType("comment")
+        comment.Commentaireia = object
+        webapp = types.ModuleType("webapp")
+        webapp.web_thread = FakeThread(alive_checks=0)
+        orchestrator = types.ModuleType("orchestrator")
+        orchestrator.Orchestrator = object
+        logger = types.ModuleType("logger")
+        logger.Logger = NullLogger
+
+        cls.module_patch = patch.dict(
+            sys.modules,
+            {
+                "init_shared": init_shared,
+                "display": display,
+                "comment": comment,
+                "webapp": webapp,
+                "orchestrator": orchestrator,
+                "logger": logger,
+            },
+        )
+        cls.module_patch.start()
+
+        module_path = Path(__file__).resolve().parents[1] / "Bjorn.py"
+        module_spec = importlib.util.spec_from_file_location(
+            cls.MODULE_NAME,
+            module_path,
+        )
+        if module_spec is None or module_spec.loader is None:
+            raise RuntimeError(f"Cannot load Bjorn module from {module_path}")
+        cls.bjorn_module = importlib.util.module_from_spec(module_spec)
+        sys.modules[cls.MODULE_NAME] = cls.bjorn_module
+        module_spec.loader.exec_module(cls.bjorn_module)
+
+    @classmethod
+    def tearDownClass(cls):
+        sys.modules.pop(cls.MODULE_NAME, None)
+        cls.module_patch.stop()
+
+    def setUp(self):
+        self.shared_data.should_exit = False
+        self.shared_data.orchestrator_should_exit = False
+        self.shared_data.display_should_exit = False
+        self.shared_data.webapp_should_exit = False
+
+    def test_primary_thread_is_joined_until_it_stops(self):
+        primary_thread = FakeThread(alive_checks=3)
+
+        self.bjorn_module.wait_for_primary_thread(primary_thread)
+
+        self.assertEqual(primary_thread.join_timeouts, [1, 1, 1])
+
+    def test_exit_handler_stops_and_joins_every_owned_thread(self):
+        display = FakeDisplay()
+        display_thread = FakeThread(name="Display")
+        primary_thread = FakeThread(name="Primary")
+        orchestrator_thread = FakeThread(name="Orchestrator")
+        web_thread = FakeThread(name="Web")
+        bjorn = SimpleNamespace(orchestrator_thread=orchestrator_thread)
+
+        with self.assertRaises(SystemExit) as exit_context:
+            self.bjorn_module.handle_exit(
+                15,
+                None,
+                display,
+                display_thread,
+                bjorn,
+                primary_thread,
+                web_thread,
+            )
+
+        self.assertEqual(exit_context.exception.code, 0)
+        self.assertTrue(display.stop_requested)
+        self.assertTrue(display.hardware_closed)
+        self.assertTrue(self.shared_data.should_exit)
+        self.assertTrue(self.shared_data.orchestrator_should_exit)
+        self.assertTrue(self.shared_data.display_should_exit)
+        self.assertTrue(self.shared_data.webapp_should_exit)
+        joined_threads = [
+            display_thread,
+            *display.workers,
+            primary_thread,
+            orchestrator_thread,
+            web_thread,
+        ]
+        for thread in joined_threads:
+            self.assertEqual(len(thread.join_timeouts), 1)
+            self.assertGreater(thread.join_timeouts[0], 0)
+            self.assertLessEqual(thread.join_timeouts[0], 0.25)
+
+    def test_shutdown_wait_reports_threads_that_miss_deadline(self):
+        stuck_thread = FakeThread(
+            alive_checks=1,
+            name="StuckWorker",
+        )
+
+        alive_names = self.bjorn_module.wait_for_shutdown_threads(
+            [stuck_thread],
+            timeout=0,
+        )
+
+        self.assertEqual(alive_names, ["StuckWorker"])
+
+    def test_shutdown_wait_reports_a_thread_with_custom_join_failure(self):
+        gpio_thread = FakeThread(
+            name="GPIOHold",
+            join_error=RuntimeError(
+                "Thread failed to die within 0.25 seconds"
+            ),
+        )
+
+        alive_names = self.bjorn_module.wait_for_shutdown_threads(
+            [gpio_thread],
+            timeout=1,
+        )
+
+        self.assertEqual(alive_names, ["GPIOHold"])
+
+    def test_exit_handler_waits_for_residual_python_threads(self):
+        display = FakeDisplay()
+        residual_thread = FakeThread(name="LibraryRefresh")
+        current_thread = object()
+        bjorn = SimpleNamespace(orchestrator_thread=None)
+
+        with (
+            patch.object(
+                self.bjorn_module.threading,
+                "current_thread",
+                return_value=current_thread,
+            ),
+            patch.object(
+                self.bjorn_module.threading,
+                "enumerate",
+                return_value=[current_thread, residual_thread],
+            ),
+            self.assertRaises(SystemExit) as exit_context,
+        ):
+            self.bjorn_module.handle_exit(
+                15,
+                None,
+                display,
+                FakeThread(name="Display"),
+                bjorn,
+                FakeThread(name="Primary"),
+                FakeThread(name="Web"),
+            )
+
+        self.assertEqual(exit_context.exception.code, 0)
+        self.assertEqual(len(residual_thread.join_timeouts), 1)
+        self.assertGreater(residual_thread.join_timeouts[0], 0)
+
+    def test_exit_handler_rejects_a_stuck_residual_thread(self):
+        display = FakeDisplay()
+        residual_thread = FakeThread(
+            alive_checks=2,
+            name="StuckLibraryThread",
+        )
+        current_thread = object()
+        bjorn = SimpleNamespace(orchestrator_thread=None)
+
+        with (
+            patch.object(
+                self.bjorn_module.threading,
+                "current_thread",
+                return_value=current_thread,
+            ),
+            patch.object(
+                self.bjorn_module.threading,
+                "enumerate",
+                return_value=[current_thread, residual_thread],
+            ),
+            patch.object(
+                self.bjorn_module,
+                "RESIDUAL_THREAD_GRACE_SECONDS",
+                0,
+            ),
+            self.assertRaises(SystemExit) as exit_context,
+        ):
+            self.bjorn_module.handle_exit(
+                15,
+                None,
+                display,
+                FakeThread(name="Display"),
+                bjorn,
+                FakeThread(name="Primary"),
+                FakeThread(name="Web"),
+            )
+
+        self.assertEqual(exit_context.exception.code, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_combined_installer.py
+++ b/tests/test_combined_installer.py
@@ -1,0 +1,74 @@
+"""Regression tests for the combined transactional installer."""
+
+import re
+import unittest
+from pathlib import Path
+
+
+PROJECT_DIR = Path(__file__).resolve().parents[1]
+INSTALLER_PATH = PROJECT_DIR / "install_stability_web_auth.sh"
+
+
+class CombinedInstallerTests(unittest.TestCase):
+    """Keep deployment and recovery ordering explicit and reviewable."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.installer = INSTALLER_PATH.read_text(encoding="utf-8")
+
+    def function_body(self, name):
+        match = re.search(
+            rf"^{re.escape(name)}\(\) \{{\n(?P<body>.*?)^\}}\n",
+            self.installer,
+            flags=re.MULTILINE | re.DOTALL,
+        )
+        self.assertIsNotNone(match, f"missing shell function: {name}")
+        return match.group("body")
+
+    def test_port_readiness_is_verified_with_a_real_bind_probe(self):
+        body = self.function_body("wait_for_web_port_release")
+        self.assertIn("probe.bind((\"\", port))", body)
+        self.assertIn("socket.SO_REUSEADDR", body)
+        self.assertNotIn("return 0\n    fi", body)
+
+    def test_failed_deployment_stops_before_overwriting_recovery_files(self):
+        body = self.function_body("on_exit")
+        stop_position = body.index("stop_before_restore")
+        restore_position = body.index("restore_snapshot")
+        start_position = body.index("start_and_verify")
+        self.assertLess(stop_position, restore_position)
+        self.assertLess(restore_position, start_position)
+
+    def test_recovery_requires_process_exit_before_file_restore(self):
+        body = self.function_body("stop_before_restore")
+        self.assertIn("systemctl is-active --quiet", body)
+        self.assertIn("pgrep -f", body)
+        self.assertIn("refusing to restore files", body)
+
+    def test_startup_verification_checks_service_and_expected_http(self):
+        body = self.function_body("start_and_verify")
+        self.assertIn("must be inactive before startup", body)
+        self.assertIn("systemctl is-active --quiet", body)
+        self.assertIn('HTTP_STATUS" != "200"', body)
+        self.assertIn('HTTP_STATUS" != "401"', body)
+
+    def test_human_output_keeps_statuses_and_machine_markers(self):
+        self.assertIn('${NO_COLOR:-}', self.installer)
+        for function_name in (
+            "banner",
+            "step",
+            "info",
+            "success",
+            "warning",
+            "error",
+            "summary_row",
+            "complete",
+        ):
+            self.function_body(function_name)
+        self.assertIn("Machine marker: INSTALL_OK", self.installer)
+        self.assertIn("Machine marker: RESTORE_OK", self.installer)
+        self.assertIn("Machine marker: RECOVERY_OK", self.installer)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_combined_installer.py
+++ b/tests/test_combined_installer.py
@@ -1,6 +1,10 @@
 """Regression tests for the combined transactional installer."""
 
+import os
 import re
+import shutil
+import subprocess
+import textwrap
 import unittest
 from pathlib import Path
 
@@ -38,6 +42,47 @@ class CombinedInstallerTests(unittest.TestCase):
         start_position = body.index("start_and_verify")
         self.assertLess(stop_position, restore_position)
         self.assertLess(restore_position, start_position)
+
+    def test_fatal_validation_helper_exits_instead_of_returning(self):
+        body = self.function_body("fail")
+        self.assertIn("exit 1", body)
+        self.assertNotIn("return 1", body)
+
+    def test_fatal_validation_cannot_be_swallowed_by_conditional_function(self):
+        if os.name == "nt":
+            self.skipTest("native bash behavior test runs on Linux")
+        bash = shutil.which("bash")
+        if bash is None:
+            self.skipTest("bash is required for installer behavior testing")
+
+        script = textwrap.dedent(
+            f"""
+            set -e
+            error() {{ printf 'ERROR: %s\\n' "$*" >&2; }}
+            fail() {{
+            {self.function_body("fail")}
+            }}
+            nested_validation() {{
+                [[ -d /definitely/not/a/real/bjorn/target ]] || \
+                    fail "missing target"
+                printf 'VALIDATION_CONTINUED\\n'
+            }}
+            if nested_validation; then
+                printf 'CONDITIONAL_SUCCEEDED\\n'
+            fi
+            printf 'SCRIPT_CONTINUED\\n'
+            """
+        )
+        completed = subprocess.run(
+            [bash, "-c", script],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(completed.returncode, 1)
+        self.assertIn("missing target", completed.stderr)
+        self.assertNotIn("CONTINUED", completed.stdout)
 
     def test_recovery_requires_process_exit_before_file_restore(self):
         body = self.function_body("stop_before_restore")

--- a/tests/test_configure_web_auth.py
+++ b/tests/test_configure_web_auth.py
@@ -1,0 +1,89 @@
+import io
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+import configure_web_auth
+from web_auth import CredentialStore
+
+
+class ConfigureWebAuthTests(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.credential_file = Path(self.temp_dir.name) / "web_auth.json"
+        self.file_patch = patch.object(
+            configure_web_auth,
+            "CREDENTIAL_FILE",
+            self.credential_file,
+        )
+        self.file_patch.start()
+
+    def tearDown(self):
+        self.file_patch.stop()
+        self.temp_dir.cleanup()
+
+    def run_command(self, arguments, standard_input=""):
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with (
+            patch("sys.stdin", io.StringIO(standard_input)),
+            redirect_stdout(stdout),
+            redirect_stderr(stderr),
+        ):
+            result = configure_web_auth.main(arguments)
+        return result, stdout.getvalue(), stderr.getvalue()
+
+    def test_password_stdin_sets_hashed_credentials(self):
+        result, stdout, stderr = self.run_command(
+            ["set", "validation-user", "--password-stdin"],
+            "temporary validation password\n",
+        )
+
+        self.assertEqual(result, 0)
+        self.assertEqual(stderr, "")
+        self.assertIn("validation-user", stdout)
+        store = CredentialStore(self.credential_file)
+        self.assertTrue(
+            store.verify(
+                "validation-user",
+                "temporary validation password",
+            )
+        )
+        self.assertNotIn(
+            "temporary validation password",
+            self.credential_file.read_text(encoding="utf-8"),
+        )
+
+    def test_empty_password_stdin_is_rejected(self):
+        result, _, stderr = self.run_command(
+            ["set", "validation-user", "--password-stdin"],
+        )
+
+        self.assertEqual(result, 1)
+        self.assertIn("No password was provided", stderr)
+        self.assertFalse(self.credential_file.exists())
+
+    def test_status_disable_and_enable_commands(self):
+        self.run_command(
+            ["set", "validation-user", "--password-stdin"],
+            "temporary validation password\n",
+        )
+
+        result, stdout, _ = self.run_command(["status"])
+        self.assertEqual(result, 0)
+        self.assertIn("Credentials configured: yes", stdout)
+        self.assertIn("Authentication enabled: yes", stdout)
+
+        result, _, _ = self.run_command(["disable"])
+        self.assertEqual(result, 0)
+        self.assertFalse(CredentialStore(self.credential_file).auth_required())
+
+        result, _, _ = self.run_command(["enable"])
+        self.assertEqual(result, 0)
+        self.assertTrue(CredentialStore(self.credential_file).auth_required())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_display_shutdown.py
+++ b/tests/test_display_shutdown.py
@@ -1,0 +1,126 @@
+import importlib.util
+import sys
+import threading
+import time
+import types
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+
+class NullLogger:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def debug(self, _message):
+        pass
+
+    def error(self, _message):
+        pass
+
+    def info(self, _message):
+        pass
+
+    def warning(self, _message):
+        pass
+
+
+def display_import_stubs():
+    pandas = types.ModuleType("pandas")
+    pandas.DataFrame = object
+
+    pil = types.ModuleType("PIL")
+    pil.Image = object
+    pil.ImageDraw = object
+
+    init_shared = types.ModuleType("init_shared")
+    init_shared.shared_data = object()
+
+    comment = types.ModuleType("comment")
+    comment.Commentaireia = object
+
+    logger = types.ModuleType("logger")
+    logger.Logger = NullLogger
+
+    return {
+        "pandas": pandas,
+        "PIL": pil,
+        "init_shared": init_shared,
+        "comment": comment,
+        "logger": logger,
+    }
+
+
+class DisplayShutdownTests(unittest.TestCase):
+    MODULE_NAME = "_bjorn_display_shutdown_under_test"
+
+    @classmethod
+    def setUpClass(cls):
+        cls.module_patch = patch.dict(sys.modules, display_import_stubs())
+        cls.module_patch.start()
+        module_path = Path(__file__).resolve().parents[1] / "display.py"
+        module_spec = importlib.util.spec_from_file_location(
+            cls.MODULE_NAME,
+            module_path,
+        )
+        if module_spec is None or module_spec.loader is None:
+            raise RuntimeError(f"Cannot load display module from {module_path}")
+        cls.display_module = importlib.util.module_from_spec(module_spec)
+        sys.modules[cls.MODULE_NAME] = cls.display_module
+        module_spec.loader.exec_module(cls.display_module)
+
+    @classmethod
+    def tearDownClass(cls):
+        sys.modules.pop(cls.MODULE_NAME, None)
+        cls.module_patch.stop()
+
+    def make_display(self):
+        display = object.__new__(self.display_module.Display)
+        display.shared_data = SimpleNamespace(display_should_exit=False)
+        display.shutdown_event = threading.Event()
+        return display
+
+    def test_request_stop_wakes_a_long_display_wait(self):
+        display = self.make_display()
+        wait_result = []
+        waiter = threading.Thread(
+            target=lambda: wait_result.append(display.wait_or_stop(300))
+        )
+        waiter.start()
+        time.sleep(0.01)
+
+        display.request_stop()
+        waiter.join(timeout=0.5)
+
+        self.assertFalse(waiter.is_alive())
+        self.assertEqual(wait_result, [True])
+        self.assertTrue(display.shared_data.display_should_exit)
+        self.assertTrue(display.shutdown_event.is_set())
+
+    def test_background_threads_returns_every_owned_worker(self):
+        display = self.make_display()
+        display.main_image_thread = object()
+        display.update_shared_data_thread = object()
+        display.update_vuln_count_thread = object()
+
+        self.assertEqual(
+            display.background_threads(),
+            [
+                display.main_image_thread,
+                display.update_shared_data_thread,
+                display.update_vuln_count_thread,
+            ],
+        )
+
+    def test_close_hardware_delegates_to_epd_helper(self):
+        display = self.make_display()
+        display.epd_helper = SimpleNamespace(shutdown=Mock())
+
+        display.close_hardware()
+
+        display.epd_helper.shutdown.assert_called_once_with()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_epd_helper_shutdown.py
+++ b/tests/test_epd_helper_shutdown.py
@@ -1,0 +1,118 @@
+import sys
+import types
+import unittest
+from unittest.mock import Mock, patch
+
+from epd_helper import EPDHelper
+
+
+class EPDHelperShutdownTests(unittest.TestCase):
+    def make_helper(self, sleep_side_effect=None):
+        devices = {
+            name: SimpleClosable()
+            for name in (
+                "GPIO_RST_PIN",
+                "GPIO_DC_PIN",
+                "GPIO_PWR_PIN",
+                "GPIO_BUSY_PIN",
+            )
+        }
+        implementation = types.SimpleNamespace(**devices)
+        epdconfig = types.SimpleNamespace(implementation=implementation)
+        helper = object.__new__(EPDHelper)
+        helper.epd_type = "epd2in13_V4"
+        helper.epd_module = types.SimpleNamespace(epdconfig=epdconfig)
+        helper._shutdown_complete = False
+        helper.epd = types.SimpleNamespace(
+            sleep=Mock(side_effect=sleep_side_effect)
+        )
+        pin_factory = SimpleClosable()
+        gpiozero = types.ModuleType("gpiozero")
+        gpiozero.Device = types.SimpleNamespace(pin_factory=pin_factory)
+        notify_thread = FakeNotifyThread()
+        lgpio = types.ModuleType("lgpio")
+        lgpio._notify_thread = notify_thread
+        lgpio.notify_close = Mock()
+        return (
+            helper,
+            devices,
+            pin_factory,
+            gpiozero,
+            lgpio,
+            notify_thread,
+        )
+
+    def test_shutdown_releases_panel_devices_and_pin_factory_once(self):
+        (
+            helper,
+            devices,
+            pin_factory,
+            gpiozero,
+            lgpio,
+            notify_thread,
+        ) = self.make_helper()
+
+        with patch.dict(
+            sys.modules,
+            {"gpiozero": gpiozero, "lgpio": lgpio},
+        ):
+            helper.shutdown()
+            helper.shutdown()
+
+        helper.epd.sleep.assert_called_once_with()
+        for device in devices.values():
+            self.assertEqual(device.close_count, 1)
+        self.assertEqual(pin_factory.close_count, 1)
+        self.assertEqual(notify_thread.stop_count, 1)
+        self.assertEqual(notify_thread.join_timeouts, [1])
+        lgpio.notify_close.assert_called_once_with(17)
+
+    def test_gpio_cleanup_still_runs_when_panel_sleep_fails(self):
+        (
+            helper,
+            devices,
+            pin_factory,
+            gpiozero,
+            lgpio,
+            notify_thread,
+        ) = self.make_helper(RuntimeError("sleep failed"))
+
+        with patch.dict(
+            sys.modules,
+            {"gpiozero": gpiozero, "lgpio": lgpio},
+        ):
+            helper.shutdown()
+
+        for device in devices.values():
+            self.assertEqual(device.close_count, 1)
+        self.assertEqual(pin_factory.close_count, 1)
+        self.assertEqual(notify_thread.stop_count, 1)
+        lgpio.notify_close.assert_called_once_with(17)
+
+
+class SimpleClosable:
+    def __init__(self):
+        self.close_count = 0
+
+    def close(self):
+        self.close_count += 1
+
+
+class FakeNotifyThread:
+    def __init__(self):
+        self._notify = 17
+        self.stop_count = 0
+        self.join_timeouts = []
+
+    def stop(self):
+        self.stop_count += 1
+
+    def join(self, timeout=None):
+        self.join_timeouts.append(timeout)
+
+    def is_alive(self):
+        return False
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_install_bjorn_integration.py
+++ b/tests/test_install_bjorn_integration.py
@@ -1,0 +1,108 @@
+"""Regression tests for fresh-install integration and its safe plan view."""
+
+import re
+import unittest
+from pathlib import Path
+
+
+PROJECT_DIR = Path(__file__).resolve().parents[1]
+INSTALLER_PATH = PROJECT_DIR / "install_bjorn.sh"
+
+
+class FreshInstallerIntegrationTests(unittest.TestCase):
+    """Keep optional authentication visible and safe during fresh installs."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.installer = INSTALLER_PATH.read_text(encoding="utf-8")
+
+    def function_body(self, name):
+        match = re.search(
+            rf"^{re.escape(name)}\(\) \{{\n(?P<body>.*?)^\}}\n",
+            self.installer,
+            flags=re.MULTILINE | re.DOTALL,
+        )
+        self.assertIsNotNone(match, f"missing shell function: {name}")
+        return match.group("body")
+
+    def test_full_install_has_nine_ordered_steps(self):
+        expected_steps = (
+            "Checking system compatibility",
+            "Installing system dependencies",
+            "Configuring system limits",
+            "Configuring interfaces",
+            "Setting up BJORN",
+            "Installing optional web-authentication tools",
+            "Configuring USB Gadget",
+            "Setting up services",
+            "Verifying installation",
+        )
+        positions = [self.installer.index(f'"{step}"') for step in expected_steps]
+        self.assertEqual(positions, sorted(positions))
+        self.assertIn('TOTAL_STEPS="${#FULL_INSTALL_STEPS[@]}"', self.installer)
+
+    def test_authentication_password_is_prompted_by_python_not_shell(self):
+        body = self.function_body("configure_web_auth")
+        self.assertRegex(
+            body,
+            r'configure_web_auth\.py"\s*\\\s*set "\$web_username"',
+        )
+        self.assertNotIn("read -s", body)
+        self.assertIn('chmod 600 "$BJORN_PATH/config/web_auth.json"', body)
+
+    def test_fresh_install_makes_management_command_optional(self):
+        setup_body = self.function_body("setup_bjorn")
+        auth_body = self.function_body("configure_web_auth")
+        self.assertNotIn("/usr/local/sbin/http_auth", setup_body)
+        self.assertIn("Install the http_auth management command?", auth_body)
+        self.assertIn("HTTP_AUTH_COMMAND_PATH", auth_body)
+        self.assertIn(
+            'chmod 755 "$BJORN_PATH/configure_web_auth.py"',
+            auth_body,
+        )
+        self.assertIn("sudo http_auth set <username>", auth_body)
+
+    def test_show_plan_exits_before_log_or_system_changes(self):
+        show_plan_position = self.installer.index("--show-plan)")
+        log_directory_position = self.installer.index(
+            'LOG_DIR="${LOG_DIR:-/var/log/bjorn_install}"'
+        )
+        self.assertLess(show_plan_position, log_directory_position)
+
+    def test_installer_can_be_sourced_for_isolated_integration_testing(self):
+        self.assertIn(
+            'if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then\n    main "$@"',
+            self.installer,
+        )
+        self.assertIn(
+            'HTTP_AUTH_COMMAND_PATH="${HTTP_AUTH_COMMAND_PATH:-'
+            '/usr/local/sbin/http_auth}"',
+            self.installer,
+        )
+
+    def test_credential_failure_has_a_real_retry_loop(self):
+        body = self.function_body("configure_web_auth")
+        self.assertIn("while true; do", body)
+        self.assertIn("Retry credential setup? (Y/n):", body)
+        self.assertLess(
+            body.index('if python3 "$BJORN_PATH/configure_web_auth.py"'),
+            body.index('chown "$BJORN_USER:$BJORN_USER"'),
+        )
+
+    def test_generic_required_failure_aborts_instead_of_fake_retry(self):
+        body = self.function_body("handle_error")
+        self.assertNotIn("Retry this step", body)
+        self.assertIn('clean_exit "$error_code"', body)
+
+    def test_fresh_install_starts_and_strictly_verifies_service(self):
+        services_body = self.function_body("setup_services")
+        verify_body = self.function_body("verify_installation")
+        self.assertIn("systemctl restart bjorn.service", services_body)
+        self.assertIn('http_status" == "200"', verify_body)
+        self.assertIn('http_status" == "401"', verify_body)
+        self.assertIn('log "ERROR" "BJORN service is not running"', verify_body)
+        self.assertIn('return "$verification_failed"', verify_body)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_scanning_workers.py
+++ b/tests/test_scanning_workers.py
@@ -1,0 +1,368 @@
+import importlib
+import ipaddress
+import os
+import subprocess
+import sys
+import tempfile
+import threading
+import types
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+
+class NullLogger:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def error(self, message):
+        pass
+
+    def info(self, message):
+        pass
+
+    def warning(self, message):
+        pass
+
+
+def scanning_import_stubs():
+    """Return lightweight stubs for dependencies unused by these unit tests."""
+    pandas = types.ModuleType("pandas")
+    netifaces = types.ModuleType("netifaces")
+    netifaces.AF_INET = 2
+
+    rich = types.ModuleType("rich")
+    rich_console = types.ModuleType("rich.console")
+    rich_console.Console = object
+    rich_table = types.ModuleType("rich.table")
+    rich_table.Table = object
+    rich_text = types.ModuleType("rich.text")
+    rich_text.Text = str
+    rich_progress = types.ModuleType("rich.progress")
+    rich_progress.Progress = object
+
+    getmac = types.ModuleType("getmac")
+    getmac.get_mac_address = lambda **kwargs: None
+
+    shared = types.ModuleType("shared")
+    shared.SharedData = object
+
+    logger = types.ModuleType("logger")
+    logger.Logger = NullLogger
+
+    nmap = types.ModuleType("nmap")
+    nmap.PortScanner = object
+
+    return {
+        "pandas": pandas,
+        "netifaces": netifaces,
+        "rich": rich,
+        "rich.console": rich_console,
+        "rich.table": rich_table,
+        "rich.text": rich_text,
+        "rich.progress": rich_progress,
+        "getmac": getmac,
+        "shared": shared,
+        "logger": logger,
+        "nmap": nmap,
+    }
+
+
+class FakeNmapScanner:
+    def __init__(self, hosts):
+        self.hosts = hosts
+
+    def all_hosts(self):
+        return self.hosts
+
+
+class ScanningWorkerTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.module_patch = patch.dict(sys.modules, scanning_import_stubs())
+        cls.module_patch.start()
+        sys.modules.pop("actions.scanning", None)
+        cls.scanning_module = importlib.import_module("actions.scanning")
+        cls.network_scanner = cls.scanning_module.NetworkScanner
+
+    @classmethod
+    def tearDownClass(cls):
+        sys.modules.pop("actions.scanning", None)
+        cls.module_patch.stop()
+
+    def test_port_scanner_waits_for_workers_and_deduplicates_ports(self):
+        outer = SimpleNamespace(
+            lock=threading.Lock(),
+            logger=Mock(),
+            shutdown_requested=Mock(return_value=False),
+        )
+        open_ports = {"192.0.2.10": []}
+        scanner = self.network_scanner.PortScanner(
+            outer,
+            "192.0.2.10",
+            open_ports,
+            20,
+            24,
+            [22, 80],
+        )
+
+        started = threading.Event()
+        release = threading.Event()
+        completed = []
+
+        def delayed_scan(port):
+            started.set()
+            release.wait(timeout=2)
+            completed.append(port)
+
+        scanner.scan = delayed_scan
+        runner = threading.Thread(target=scanner.start)
+        runner.start()
+
+        self.assertTrue(started.wait(timeout=1))
+        self.assertTrue(runner.is_alive())
+
+        release.set()
+        runner.join(timeout=2)
+
+        self.assertFalse(runner.is_alive())
+        self.assertEqual(sorted(completed), [20, 21, 22, 23, 80])
+
+    def test_worker_limits_fit_resource_constrained_devices(self):
+        self.assertLessEqual(
+            self.scanning_module.MAX_PORT_SCAN_WORKERS,
+            32,
+        )
+        self.assertLessEqual(
+            self.scanning_module.MAX_HOST_SCAN_WORKERS,
+            16,
+        )
+
+    def test_progress_updates_without_a_background_refresh_thread(self):
+        progress_options = []
+        progress_updates = []
+
+        class FakeProgress:
+            def __init__(self, **kwargs):
+                progress_options.append(kwargs)
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc_value, traceback):
+                del exc_type, exc_value, traceback
+
+            def add_task(self, description, total):
+                del description, total
+                return 1
+
+            def update(self, task, **kwargs):
+                del task
+                progress_updates.append(kwargs)
+
+        class FakePortScanner:
+            def __init__(self, *args, **kwargs):
+                del args, kwargs
+
+            def start(self):
+                pass
+
+        outer = SimpleNamespace(
+            GetIpFromCsv=Mock(
+                return_value=SimpleNamespace(
+                    ip_list=["192.0.2.10"],
+                )
+            ),
+            PortScanner=FakePortScanner,
+            shutdown_requested=Mock(return_value=False),
+            wait_or_cancel=Mock(),
+        )
+        scan_ports = object.__new__(self.network_scanner.ScanPorts)
+        scan_ports.outer_instance = outer
+        scan_ports.scan_network_and_write_to_csv = Mock()
+        scan_ports.csv_scan_file = "scan.csv"
+        scan_ports.portstart = 1
+        scan_ports.portend = 2
+        scan_ports.extra_ports = []
+        scan_ports.csv_result_file = "result.csv"
+        scan_ports.netkbfile = "netkb.csv"
+
+        with (
+            patch.object(self.scanning_module, "Progress", FakeProgress),
+            patch.object(self.scanning_module.time, "sleep"),
+        ):
+            scan_ports.start()
+
+        self.assertEqual(progress_options, [{"auto_refresh": False}])
+        self.assertEqual(
+            progress_updates,
+            [{"advance": 1, "refresh": True}],
+        )
+
+    def test_expected_shutdown_does_not_log_scan_exception_as_error(self):
+        scanner = object.__new__(self.network_scanner)
+        scanner.shared_data = SimpleNamespace(
+            should_exit=True,
+            orchestrator_should_exit=True,
+        )
+        scanner.logger = Mock()
+        scanner.get_network = Mock(
+            side_effect=RuntimeError("interrupted nmap XML")
+        )
+
+        scanner.scan()
+
+        scanner.logger.error.assert_not_called()
+        scanner.logger.info.assert_any_call(
+            "Network scan stopped during application shutdown."
+        )
+
+    def test_host_discovery_parses_completed_nmap_xml(self):
+        scanner = object.__new__(self.network_scanner)
+        scanner.shared_data = SimpleNamespace(
+            should_exit=False,
+            orchestrator_should_exit=False,
+        )
+        scanner.discovery_process = None
+        scanner.nm = SimpleNamespace(
+            _nmap_path="/usr/bin/nmap",
+            analyse_nmap_xml_scan=Mock(),
+        )
+        process = Mock()
+        process.communicate.return_value = (
+            b"<nmaprun></nmaprun>",
+            b"",
+        )
+        process.poll.return_value = 0
+
+        with patch.object(
+            self.scanning_module.subprocess,
+            "Popen",
+            return_value=process,
+        ) as popen:
+            scanner.run_host_discovery(
+                ipaddress.ip_network("192.0.2.0/24")
+            )
+
+        popen.assert_called_once_with(
+            [
+                "/usr/bin/nmap",
+                "-oX",
+                "-",
+                "192.0.2.0/24",
+                "-sn",
+            ],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        scanner.nm.analyse_nmap_xml_scan.assert_called_once_with(
+            nmap_xml_output=b"<nmaprun></nmaprun>",
+            nmap_err="",
+        )
+        self.assertIsNone(scanner.discovery_process)
+
+    def test_host_discovery_terminates_nmap_during_shutdown(self):
+        scanner = object.__new__(self.network_scanner)
+        scanner.shared_data = SimpleNamespace(
+            should_exit=False,
+            orchestrator_should_exit=False,
+        )
+        scanner.discovery_process = None
+        scanner.nm = SimpleNamespace(
+            _nmap_path="/usr/bin/nmap",
+            analyse_nmap_xml_scan=Mock(),
+        )
+
+        class BlockingProcess:
+            def __init__(self):
+                self.terminated = False
+
+            def communicate(self, timeout=None):
+                if not self.terminated:
+                    scanner.shared_data.should_exit = True
+                    raise subprocess.TimeoutExpired("nmap", timeout)
+                return b"", b""
+
+            def poll(self):
+                return 0 if self.terminated else None
+
+            def terminate(self):
+                self.terminated = True
+
+            def kill(self):
+                self.terminated = True
+
+        process = BlockingProcess()
+        with (
+            patch.object(
+                self.scanning_module.subprocess,
+                "Popen",
+                return_value=process,
+            ),
+            self.assertRaises(
+                self.scanning_module.NetworkScanCancelled
+            ),
+        ):
+            scanner.run_host_discovery(
+                ipaddress.ip_network("192.0.2.0/24")
+            )
+
+        self.assertTrue(process.terminated)
+        scanner.nm.analyse_nmap_xml_scan.assert_not_called()
+        self.assertIsNone(scanner.discovery_process)
+
+    def test_host_discovery_waits_for_workers_before_sorting_results(self):
+        hosts = ["192.0.2.10", "192.0.2.11"]
+        workers_finished = threading.Event()
+        release = threading.Event()
+        completed = []
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            csv_scan_file = os.path.join(temp_dir, "scan.csv")
+            outer = SimpleNamespace(
+                lock=threading.Lock(),
+                logger=Mock(),
+                nm=FakeNmapScanner(hosts),
+                run_host_discovery=Mock(),
+                shutdown_requested=Mock(return_value=False),
+                check_if_csv_scan_file_exists=Mock(),
+                sort_and_write_csv=Mock(),
+            )
+
+            scan_ports = object.__new__(self.network_scanner.ScanPorts)
+            scan_ports.outer_instance = outer
+            scan_ports.network = ipaddress.ip_network("192.0.2.0/24")
+            scan_ports.csv_scan_file = csv_scan_file
+            scan_ports.csv_result_file = os.path.join(temp_dir, "result.csv")
+            scan_ports.netkbfile = os.path.join(temp_dir, "netkb.csv")
+
+            def delayed_host_scan(host):
+                release.wait(timeout=2)
+                completed.append(host)
+                if len(completed) == len(hosts):
+                    workers_finished.set()
+
+            scan_ports.scan_host = delayed_host_scan
+            runner = threading.Thread(
+                target=scan_ports.scan_network_and_write_to_csv
+            )
+            runner.start()
+
+            self.assertTrue(runner.is_alive())
+            self.assertFalse(outer.sort_and_write_csv.called)
+
+            release.set()
+            self.assertTrue(workers_finished.wait(timeout=1))
+            runner.join(timeout=2)
+
+            self.assertFalse(runner.is_alive())
+            self.assertCountEqual(completed, hosts)
+            outer.run_host_discovery.assert_called_once_with(
+                scan_ports.network
+            )
+            outer.sort_and_write_csv.assert_called_once_with(csv_scan_file)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_scanning_workers.py
+++ b/tests/test_scanning_workers.py
@@ -10,6 +10,11 @@ import unittest
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
+try:
+    import pandas as real_pandas
+except ImportError:
+    real_pandas = None
+
 
 class NullLogger:
     def __init__(self, *args, **kwargs):
@@ -27,7 +32,7 @@ class NullLogger:
 
 def scanning_import_stubs():
     """Return lightweight stubs for dependencies unused by these unit tests."""
-    pandas = types.ModuleType("pandas")
+    pandas = real_pandas or types.ModuleType("pandas")
     netifaces = types.ModuleType("netifaces")
     netifaces.AF_INET = 2
 
@@ -127,6 +132,26 @@ class ScanningWorkerTests(unittest.TestCase):
 
         self.assertFalse(runner.is_alive())
         self.assertEqual(sorted(completed), [20, 21, 22, 23, 80])
+
+    def test_port_scanner_propagates_worker_exceptions(self):
+        outer = SimpleNamespace(
+            lock=threading.Lock(),
+            logger=Mock(),
+            shutdown_requested=Mock(return_value=False),
+        )
+        scanner = self.network_scanner.PortScanner(
+            outer,
+            "192.0.2.10",
+            {"192.0.2.10": []},
+            22,
+            23,
+            [],
+        )
+
+        scanner.scan = Mock(side_effect=RuntimeError("port worker failed"))
+
+        with self.assertRaisesRegex(RuntimeError, "port worker failed"):
+            scanner.start()
 
     def test_worker_limits_fit_resource_constrained_devices(self):
         self.assertLessEqual(
@@ -362,6 +387,171 @@ class ScanningWorkerTests(unittest.TestCase):
                 scan_ports.network
             )
             outer.sort_and_write_csv.assert_called_once_with(csv_scan_file)
+
+    def test_host_processing_propagates_worker_exceptions(self):
+        hosts = ["192.0.2.10"]
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            csv_scan_file = os.path.join(temp_dir, "scan.csv")
+            outer = SimpleNamespace(
+                lock=threading.Lock(),
+                logger=Mock(),
+                nm=FakeNmapScanner(hosts),
+                run_host_discovery=Mock(),
+                shutdown_requested=Mock(return_value=False),
+                check_if_csv_scan_file_exists=Mock(),
+                sort_and_write_csv=Mock(),
+            )
+
+            scan_ports = object.__new__(self.network_scanner.ScanPorts)
+            scan_ports.outer_instance = outer
+            scan_ports.network = ipaddress.ip_network("192.0.2.0/24")
+            scan_ports.csv_scan_file = csv_scan_file
+            scan_ports.csv_result_file = os.path.join(
+                temp_dir,
+                "result.csv",
+            )
+            scan_ports.netkbfile = os.path.join(temp_dir, "netkb.csv")
+            scan_ports.scan_host = Mock(
+                side_effect=RuntimeError("host worker failed")
+            )
+
+            with self.assertRaisesRegex(RuntimeError, "host worker failed"):
+                scan_ports.scan_network_and_write_to_csv()
+
+            outer.sort_and_write_csv.assert_not_called()
+
+    @unittest.skipIf(real_pandas is None, "pandas is not installed")
+    def test_livestatus_handles_numeric_ports_and_empty_values(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source_path = os.path.join(temp_dir, "netkb.csv")
+            output_path = os.path.join(temp_dir, "livestatus.csv")
+            real_pandas.DataFrame(
+                [
+                    {
+                        "MAC Address": "00:11:22:33:44:55",
+                        "Alive": 1,
+                        "Ports": 22,
+                    },
+                    {
+                        "MAC Address": "00:11:22:33:44:66",
+                        "Alive": 1,
+                        "Ports": None,
+                    },
+                ]
+            ).to_csv(source_path, index=False)
+            real_pandas.DataFrame(
+                [
+                    {
+                        "Total Open Ports": 0,
+                        "Alive Hosts Count": 0,
+                        "All Known Hosts Count": 0,
+                        "Vulnerabilities Count": 7,
+                    }
+                ]
+            ).to_csv(output_path, index=False)
+
+            updater = self.network_scanner.LiveStatusUpdater(
+                source_path,
+                output_path,
+            )
+            updater.logger = Mock()
+
+            with patch.object(self.scanning_module, "pd", real_pandas):
+                result = updater.update_livestatus()
+
+            saved = real_pandas.read_csv(output_path)
+            self.assertTrue(result)
+            self.assertEqual(saved.loc[0, "Total Open Ports"], 1)
+            self.assertEqual(saved.loc[0, "Alive Hosts Count"], 2)
+            self.assertEqual(saved.loc[0, "All Known Hosts Count"], 2)
+            self.assertEqual(saved.loc[0, "Vulnerabilities Count"], 7)
+            updater.logger.error.assert_not_called()
+            updater.logger.info.assert_any_call("Livestatus updated")
+            updater.logger.info.assert_any_call(
+                f"Results saved to {output_path}"
+            )
+
+    @unittest.skipIf(real_pandas is None, "pandas is not installed")
+    def test_livestatus_ignores_empty_port_tokens(self):
+        updater = self.network_scanner.LiveStatusUpdater(
+            "unused-source.csv",
+            "unused-output.csv",
+        )
+        updater.df = real_pandas.DataFrame(
+            [
+                {
+                    "MAC Address": "00:11:22:33:44:55",
+                    "Alive": 1,
+                    "Ports": "22; 80;;443; ",
+                },
+                {
+                    "MAC Address": "00:11:22:33:44:66",
+                    "Alive": 1,
+                    "Ports": None,
+                },
+            ]
+        )
+
+        with patch.object(self.scanning_module, "pd", real_pandas):
+            updater.calculate_open_ports()
+
+        self.assertEqual(updater.total_open_ports, 3)
+
+    def test_livestatus_failure_stops_pipeline_without_false_success(self):
+        updater = self.network_scanner.LiveStatusUpdater(
+            "unused-source.csv",
+            "unused-output.csv",
+        )
+        updater.logger = Mock()
+        updater.read_csv = Mock()
+        updater.calculate_open_ports = Mock(
+            side_effect=RuntimeError("bad ports")
+        )
+        updater.calculate_hosts_counts = Mock()
+        updater.save_results = Mock()
+
+        result = updater.update_livestatus()
+
+        self.assertFalse(result)
+        updater.calculate_hosts_counts.assert_not_called()
+        updater.save_results.assert_not_called()
+        updater.logger.error.assert_called_once_with(
+            "Error updating livestatus during calculate_open_ports: "
+            "bad ports"
+        )
+        updater.logger.info.assert_not_called()
+
+    @unittest.skipIf(real_pandas is None, "pandas is not installed")
+    def test_livestatus_missing_output_does_not_report_success(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source_path = os.path.join(temp_dir, "netkb.csv")
+            output_path = os.path.join(temp_dir, "missing.csv")
+            real_pandas.DataFrame(
+                [
+                    {
+                        "MAC Address": "00:11:22:33:44:55",
+                        "Alive": 1,
+                        "Ports": 22,
+                    }
+                ]
+            ).to_csv(source_path, index=False)
+            updater = self.network_scanner.LiveStatusUpdater(
+                source_path,
+                output_path,
+            )
+            updater.logger = Mock()
+
+            with patch.object(self.scanning_module, "pd", real_pandas):
+                result = updater.update_livestatus()
+
+            self.assertFalse(result)
+            updater.logger.error.assert_called_once()
+            self.assertIn(
+                "Error updating livestatus during save_results",
+                updater.logger.error.call_args.args[0],
+            )
+            updater.logger.info.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_web_auth.py
+++ b/tests/test_web_auth.py
@@ -1,0 +1,154 @@
+import base64
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from web_auth import (
+    BasicAuthGate,
+    CredentialError,
+    CredentialStore,
+    is_credential_file_request,
+)
+
+
+class WebAuthTests(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.credential_file = Path(self.temp_dir.name) / "web_auth.json"
+        self.store = CredentialStore(self.credential_file)
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    @staticmethod
+    def authorization_header(username, password):
+        payload = base64.b64encode(
+            f"{username}:{password}".encode("utf-8")
+        ).decode("ascii")
+        return f"Basic {payload}"
+
+    def test_missing_credentials_leave_authentication_disabled(self):
+        self.assertFalse(self.store.auth_required())
+        self.assertFalse(self.store.is_configured())
+
+    def test_credentials_are_hashed_and_valid_login_is_accepted(self):
+        self.store.save("bjornadmin", "correct horse battery staple")
+        gate = BasicAuthGate(self.store)
+
+        stored_record = json.loads(self.credential_file.read_text("utf-8"))
+        self.assertNotIn("correct horse battery staple", str(stored_record))
+        self.assertEqual(stored_record["algorithm"], "scrypt")
+        self.assertTrue(self.store.auth_required())
+        self.assertTrue(
+            gate.is_authorized(
+                self.authorization_header(
+                    "bjornadmin",
+                    "correct horse battery staple",
+                )
+            )
+        )
+
+    def test_invalid_headers_and_credentials_are_rejected(self):
+        self.store.save("bjornadmin", "correct horse battery staple")
+        gate = BasicAuthGate(self.store)
+
+        self.assertFalse(gate.is_authorized(None))
+        self.assertFalse(gate.is_authorized("Bearer token"))
+        self.assertFalse(gate.is_authorized("Basic not-base64"))
+        self.assertFalse(
+            gate.is_authorized(
+                self.authorization_header("bjornadmin", "wrong password")
+            )
+        )
+        self.assertFalse(
+            gate.is_authorized(
+                self.authorization_header(
+                    "wrong-user",
+                    "correct horse battery staple",
+                )
+            )
+        )
+
+    def test_successful_header_is_cached_until_credentials_change(self):
+        self.store.save("bjornadmin", "correct horse battery staple")
+
+        class CountingStore(CredentialStore):
+            def __init__(self, path):
+                super().__init__(path)
+                self.verify_calls = 0
+
+            def verify(self, username, password):
+                self.verify_calls += 1
+                return super().verify(username, password)
+
+        counting_store = CountingStore(self.credential_file)
+        gate = BasicAuthGate(counting_store)
+        header = self.authorization_header(
+            "bjornadmin",
+            "correct horse battery staple",
+        )
+
+        self.assertTrue(gate.is_authorized(header))
+        self.assertTrue(gate.is_authorized(header))
+        self.assertEqual(counting_store.verify_calls, 1)
+
+        counting_store.save("bjornadmin", "new correct horse password")
+        self.assertFalse(gate.is_authorized(header))
+        self.assertEqual(counting_store.verify_calls, 2)
+
+    def test_authentication_can_be_disabled_without_deleting_credentials(self):
+        self.store.save("bjornadmin", "correct horse battery staple")
+        self.store.set_enabled(False)
+
+        self.assertTrue(self.store.is_configured())
+        self.assertFalse(self.store.auth_required())
+        self.store.set_enabled(True)
+        self.assertTrue(self.store.auth_required())
+
+    def test_corrupt_existing_credential_file_fails_closed(self):
+        self.credential_file.write_text("{not-json", encoding="utf-8")
+
+        self.assertTrue(self.store.auth_required())
+        self.assertFalse(self.store.is_configured())
+
+    def test_malformed_hash_parameters_fail_closed(self):
+        self.credential_file.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "enabled": True,
+                    "username": "bjornadmin",
+                    "algorithm": "scrypt",
+                    "salt": "invalid",
+                    "password_hash": "invalid",
+                    "scrypt": {"n": "not-a-number", "r": 8, "p": 1},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        self.assertTrue(self.store.auth_required())
+        self.assertFalse(self.store.is_configured())
+
+    def test_short_password_is_rejected(self):
+        with self.assertRaises(CredentialError):
+            self.store.save("bjornadmin", "too-short")
+
+    def test_credential_file_path_cannot_be_requested_as_static_content(self):
+        protected_paths = [
+            "/config/web_auth.json",
+            "//config/web_auth.json",
+            "/config/../config/web_auth.json",
+            "/config%2Fweb_auth.json?download=1",
+            r"/config\web_auth.json",
+        ]
+        for path in protected_paths:
+            with self.subTest(path=path):
+                self.assertTrue(is_credential_file_request(path))
+
+        self.assertFalse(is_credential_file_request("/config.html"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_web_auth.py
+++ b/tests/test_web_auth.py
@@ -1,5 +1,6 @@
 import base64
 import json
+import os
 import tempfile
 import unittest
 from pathlib import Path
@@ -96,6 +97,40 @@ class WebAuthTests(unittest.TestCase):
         counting_store.save("bjornadmin", "new correct horse password")
         self.assertFalse(gate.is_authorized(header))
         self.assertEqual(counting_store.verify_calls, 2)
+
+    def test_access_metadata_change_invalidates_cached_authorization(self):
+        self.store.save("bjornadmin", "correct horse battery staple")
+
+        class CountingStore(CredentialStore):
+            def __init__(self, path):
+                super().__init__(path)
+                self.verify_calls = 0
+
+            def verify(self, username, password):
+                self.verify_calls += 1
+                return super().verify(username, password)
+
+        counting_store = CountingStore(self.credential_file)
+        gate = BasicAuthGate(counting_store)
+        header = self.authorization_header(
+            "bjornadmin",
+            "correct horse battery staple",
+        )
+
+        self.assertTrue(gate.is_authorized(header))
+        self.assertTrue(gate.is_authorized(header))
+        self.assertEqual(counting_store.verify_calls, 1)
+
+        original_signature = counting_store.file_signature()
+        try:
+            os.chmod(self.credential_file, 0o400)
+            changed_signature = counting_store.file_signature()
+
+            self.assertNotEqual(original_signature, changed_signature)
+            self.assertTrue(gate.is_authorized(header))
+            self.assertEqual(counting_store.verify_calls, 2)
+        finally:
+            os.chmod(self.credential_file, 0o600)
 
     def test_authentication_can_be_disabled_without_deleting_credentials(self):
         self.store.save("bjornadmin", "correct horse battery staple")

--- a/tests/test_webapp_auth_integration.py
+++ b/tests/test_webapp_auth_integration.py
@@ -1,0 +1,365 @@
+import base64
+import gzip
+import http.client
+import importlib.util
+import signal
+import socket
+import sys
+import tempfile
+import threading
+import types
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+class NullLogger:
+    warning_messages = []
+    error_messages = []
+
+    def __init__(self, *_args, **_kwargs):
+        pass
+
+    def info(self, _message):
+        pass
+
+    def warning(self, message):
+        type(self).warning_messages.append(message)
+
+    def error(self, message):
+        type(self).error_messages.append(message)
+
+
+class DummyWebUtils:
+    post_calls = 0
+
+    def __init__(self, shared_data, logger):
+        self.shared_data = shared_data
+        self.logger = logger
+
+    def save_configuration(self, handler):
+        type(self).post_calls += 1
+        content_length = int(handler.headers.get("Content-Length", 0))
+        if content_length:
+            handler.rfile.read(content_length)
+        handler.send_response(200)
+        handler.end_headers()
+
+
+class WebAppAuthIntegrationTests(unittest.TestCase):
+    WEBAPP_MODULE_NAME = "_bjorn_webapp_under_test"
+    GET_ROUTES = (
+        "/",
+        "/index.html",
+        "/config.html",
+        "/actions.html",
+        "/network.html",
+        "/netkb.html",
+        "/bjorn.html",
+        "/loot.html",
+        "/credentials.html",
+        "/manual.html",
+        "/load_config",
+        "/restore_default_config",
+        "/get_web_delay",
+        "/scan_wifi",
+        "/network_data",
+        "/netkb_data",
+        "/netkb_data_json",
+        "/screen.png",
+        "/favicon.ico",
+        "/manifest.json",
+        "/apple-touch-icon",
+        "/get_logs",
+        "/list_credentials",
+        "/list_files",
+        "/download_file",
+        "/download_backup",
+        "/styles.css",
+    )
+    POST_ROUTES = (
+        "/save_config",
+        "/connect_wifi",
+        "/disconnect_wifi",
+        "/clear_files",
+        "/clear_files_light",
+        "/initialize_csv",
+        "/reboot",
+        "/shutdown",
+        "/restart_bjorn_service",
+        "/backup",
+        "/restore",
+        "/stop_orchestrator",
+        "/start_orchestrator",
+        "/execute_manual_attack",
+    )
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        temp_path = Path(self.temp_dir.name)
+        web_dir = temp_path / "web"
+        web_dir.mkdir()
+        (web_dir / "index.html").write_text(
+            "<html><body>Bjorn test page</body></html>",
+            encoding="utf-8",
+        )
+
+        self.shared_data = SimpleNamespace(
+            webdir=str(web_dir),
+            web_auth_file=str(temp_path / "web_auth.json"),
+            webapp_should_exit=False,
+            web_delay=1,
+        )
+        init_shared = types.ModuleType("init_shared")
+        init_shared.shared_data = self.shared_data
+        utils = types.ModuleType("utils")
+        utils.WebUtils = DummyWebUtils
+        logger = types.ModuleType("logger")
+        logger.Logger = NullLogger
+
+        self.module_patch = patch.dict(
+            sys.modules,
+            {
+                "init_shared": init_shared,
+                "utils": utils,
+                "logger": logger,
+            },
+        )
+        self.module_patch.start()
+        sys.modules.pop(self.WEBAPP_MODULE_NAME, None)
+
+        self.previous_sigint = signal.getsignal(signal.SIGINT)
+        self.previous_sigterm = signal.getsignal(signal.SIGTERM)
+        webapp_path = Path(__file__).resolve().parents[1] / "webapp.py"
+        module_spec = importlib.util.spec_from_file_location(
+            self.WEBAPP_MODULE_NAME,
+            webapp_path,
+        )
+        if module_spec is None or module_spec.loader is None:
+            self.fail(f"Cannot load web application from {webapp_path}")
+        self.webapp = importlib.util.module_from_spec(module_spec)
+        sys.modules[self.WEBAPP_MODULE_NAME] = self.webapp
+        module_spec.loader.exec_module(self.webapp)
+
+        self.server = self.webapp.ReusableTCPServer(
+            ("127.0.0.1", 0),
+            self.webapp.CustomHandler,
+        )
+        self.server.daemon_threads = True
+        self.server_thread = threading.Thread(
+            target=self.server.serve_forever,
+            daemon=True,
+        )
+        self.server_thread.start()
+        self.port = self.server.server_address[1]
+        DummyWebUtils.post_calls = 0
+        NullLogger.warning_messages = []
+        NullLogger.error_messages = []
+
+    def tearDown(self):
+        self.server.shutdown()
+        self.server.server_close()
+        self.server_thread.join(timeout=3)
+        signal.signal(signal.SIGINT, self.previous_sigint)
+        signal.signal(signal.SIGTERM, self.previous_sigterm)
+        sys.modules.pop(self.WEBAPP_MODULE_NAME, None)
+        self.module_patch.stop()
+        self.temp_dir.cleanup()
+
+    @staticmethod
+    def authorization_header(username, password):
+        encoded = base64.b64encode(
+            f"{username}:{password}".encode("utf-8")
+        ).decode("ascii")
+        return f"Basic {encoded}"
+
+    def request(self, method, path, authorization=None, body=None):
+        headers = {}
+        if authorization is not None:
+            headers["Authorization"] = authorization
+        if body is not None:
+            headers["Content-Type"] = "application/json"
+            headers["Content-Length"] = str(len(body))
+
+        connection = http.client.HTTPConnection(
+            "127.0.0.1",
+            self.port,
+            timeout=5,
+        )
+        try:
+            connection.request(
+                method,
+                path,
+                body=body,
+                headers=headers,
+            )
+            response = connection.getresponse()
+            response_body = response.read()
+            return response.status, dict(response.getheaders()), response_body
+        finally:
+            connection.close()
+
+    def enable_authentication(self):
+        self.webapp.credential_store.save(
+            "bjornadmin",
+            "correct horse battery staple",
+        )
+        return self.authorization_header(
+            "bjornadmin",
+            "correct horse battery staple",
+        )
+
+    def test_no_credentials_preserve_current_open_behavior(self):
+        status, headers, body = self.request("GET", "/")
+
+        self.assertEqual(status, 200)
+        self.assertEqual(headers["Content-Encoding"], "gzip")
+        self.assertIn(b"Bjorn test page", gzip.decompress(body))
+
+    def test_real_http_challenge_rejects_wrong_and_accepts_valid_login(self):
+        valid_header = self.enable_authentication()
+
+        status, headers, _ = self.request("GET", "/")
+        self.assertEqual(status, 401)
+        self.assertIn("Basic realm=", headers["WWW-Authenticate"])
+
+        wrong_header = self.authorization_header("bjornadmin", "wrong")
+        status, _, _ = self.request("GET", "/", wrong_header)
+        self.assertEqual(status, 401)
+
+        status, _, body = self.request("GET", "/", valid_header)
+        self.assertEqual(status, 200)
+        self.assertIn(b"Bjorn test page", gzip.decompress(body))
+
+    def test_expected_challenge_is_silent_but_invalid_header_is_warned(self):
+        self.enable_authentication()
+
+        status, _, _ = self.request(
+            "GET",
+            "/index.html?cache-bust=expected-challenge",
+        )
+        self.assertEqual(status, 401)
+        self.assertEqual(NullLogger.warning_messages, [])
+
+        status, _, _ = self.request(
+            "GET",
+            "/index.html?private-value=must-not-be-logged",
+            authorization="Basic not-base64",
+        )
+        self.assertEqual(status, 401)
+        self.assertEqual(len(NullLogger.warning_messages), 1)
+        warning = NullLogger.warning_messages[0]
+        self.assertIn(
+            "Rejected invalid web credentials for GET /index.html",
+            warning,
+        )
+        self.assertIn("from 127.0.0.1", warning)
+        self.assertNotIn("private-value", warning)
+
+    def test_post_challenge_does_not_wait_for_an_unsent_request_body(self):
+        self.enable_authentication()
+        request_headers = (
+            "POST /save_config HTTP/1.1\r\n"
+            f"Host: 127.0.0.1:{self.port}\r\n"
+            "Content-Type: application/json\r\n"
+            "Content-Length: 1048576\r\n"
+            "Connection: keep-alive\r\n"
+            "\r\n"
+        ).encode("ascii")
+
+        client = socket.create_connection(
+            ("127.0.0.1", self.port),
+            timeout=2,
+        )
+        try:
+            client.settimeout(2)
+            client.sendall(request_headers)
+            response = client.recv(4096)
+        finally:
+            client.close()
+
+        self.assertIn(b" 401 ", response)
+        self.assertIn(b"Connection: close\r\n", response)
+        self.assertEqual(DummyWebUtils.post_calls, 0)
+
+    def test_head_post_and_private_file_are_protected(self):
+        valid_header = self.enable_authentication()
+
+        status, _, body = self.request("HEAD", "/")
+        self.assertEqual(status, 401)
+        self.assertEqual(body, b"")
+
+        status, _, _ = self.request("POST", "/save_config", body=b"{}")
+        self.assertEqual(status, 401)
+        self.assertEqual(DummyWebUtils.post_calls, 0)
+
+        status, _, _ = self.request(
+            "POST",
+            "/save_config",
+            authorization=valid_header,
+            body=b"{}",
+        )
+        self.assertEqual(status, 200)
+        self.assertEqual(DummyWebUtils.post_calls, 1)
+
+        status, _, _ = self.request(
+            "GET",
+            "/config%2Fweb_auth.json",
+            authorization=valid_header,
+        )
+        self.assertEqual(status, 404)
+
+    def test_every_known_route_requires_authentication(self):
+        self.enable_authentication()
+
+        for route in self.GET_ROUTES:
+            with self.subTest(method="GET", route=route):
+                status, _, _ = self.request("GET", route)
+                self.assertEqual(status, 401)
+
+        for route in self.POST_ROUTES:
+            with self.subTest(method="POST", route=route):
+                status, _, _ = self.request("POST", route, body=b"{}")
+                self.assertEqual(status, 401)
+
+        status, _, body = self.request("HEAD", "/")
+        self.assertEqual(status, 401)
+        self.assertEqual(body, b"")
+
+        status, _, _ = self.request("GET", "/config/web_auth.json")
+        self.assertEqual(status, 404)
+
+    def test_server_socket_allows_immediate_port_reuse(self):
+        self.assertTrue(self.webapp.ReusableTCPServer.allow_reuse_address)
+
+    def test_web_thread_has_stable_name(self):
+        web_thread = self.webapp.WebThread(
+            handler_class=self.webapp.CustomHandler,
+            port=0,
+        )
+
+        self.assertEqual(web_thread.name, "BjornWeb")
+
+    def test_web_thread_exits_promptly_after_shutdown_flag(self):
+        web_thread = self.webapp.WebThread(
+            handler_class=self.webapp.CustomHandler,
+            port=0,
+        )
+        web_thread.start()
+
+        for _ in range(100):
+            if web_thread.httpd is not None:
+                break
+            threading.Event().wait(0.01)
+        self.assertIsNotNone(web_thread.httpd)
+
+        self.shared_data.webapp_should_exit = True
+        web_thread.join(timeout=1.5)
+
+        self.assertFalse(web_thread.is_alive())
+        self.assertEqual(NullLogger.error_messages, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_webapp_auth_integration.py
+++ b/tests/test_webapp_auth_integration.py
@@ -15,14 +15,15 @@ from unittest.mock import patch
 
 
 class NullLogger:
+    info_messages = []
     warning_messages = []
     error_messages = []
 
     def __init__(self, *_args, **_kwargs):
         pass
 
-    def info(self, _message):
-        pass
+    def info(self, message):
+        type(self).info_messages.append(message)
 
     def warning(self, message):
         type(self).warning_messages.append(message)
@@ -154,6 +155,7 @@ class WebAppAuthIntegrationTests(unittest.TestCase):
         self.server_thread.start()
         self.port = self.server.server_address[1]
         DummyWebUtils.post_calls = 0
+        NullLogger.info_messages = []
         NullLogger.warning_messages = []
         NullLogger.error_messages = []
 
@@ -256,6 +258,37 @@ class WebAppAuthIntegrationTests(unittest.TestCase):
         )
         self.assertIn("from 127.0.0.1", warning)
         self.assertNotIn("private-value", warning)
+
+    def test_read_only_access_logs_are_suppressed_but_errors_remain(self):
+        status, _, _ = self.request("GET", "/")
+        self.assertEqual(status, 200)
+
+        status, _, body = self.request("HEAD", "/")
+        self.assertEqual(status, 200)
+        self.assertEqual(body, b"")
+        self.assertEqual(NullLogger.info_messages, [])
+
+        status, _, _ = self.request("GET", "/missing")
+        self.assertEqual(status, 404)
+        status, _, body = self.request("HEAD", "/missing")
+        self.assertEqual(status, 404)
+        self.assertEqual(body, b"")
+
+        self.assertEqual(len(NullLogger.info_messages), 2)
+        for message in NullLogger.info_messages:
+            self.assertIn("code 404, message File not found", message)
+            self.assertNotIn('"GET /missing', message)
+            self.assertNotIn('"HEAD /missing', message)
+
+    def test_post_path_containing_get_is_still_logged(self):
+        status, _, _ = self.request("POST", "/GET")
+
+        self.assertEqual(status, 404)
+        self.assertEqual(len(NullLogger.info_messages), 1)
+        self.assertIn(
+            '"POST /GET HTTP/1.1" 404',
+            NullLogger.info_messages[0],
+        )
 
     def test_post_challenge_does_not_wait_for_an_unsent_request_body(self):
         self.enable_authentication()

--- a/tests/test_webapp_auth_integration.py
+++ b/tests/test_webapp_auth_integration.py
@@ -341,6 +341,31 @@ class WebAppAuthIntegrationTests(unittest.TestCase):
 
         self.assertEqual(web_thread.name, "BjornWeb")
 
+    def test_web_thread_shutdown_matches_manual_request_loop(self):
+        class FakeServer:
+            def __init__(self):
+                self.close_calls = 0
+                self.shutdown_calls = 0
+
+            def server_close(self):
+                self.close_calls += 1
+
+            def shutdown(self):
+                self.shutdown_calls += 1
+
+        web_thread = self.webapp.WebThread(
+            handler_class=self.webapp.CustomHandler,
+            port=0,
+        )
+        fake_server = FakeServer()
+        web_thread.httpd = fake_server
+
+        web_thread.shutdown()
+
+        self.assertTrue(self.shared_data.webapp_should_exit)
+        self.assertEqual(fake_server.close_calls, 1)
+        self.assertEqual(fake_server.shutdown_calls, 0)
+
     def test_web_thread_exits_promptly_after_shutdown_flag(self):
         web_thread = self.webapp.WebThread(
             handler_class=self.webapp.CustomHandler,

--- a/tests/validate_scan_lifecycle.sh
+++ b/tests/validate_scan_lifecycle.sh
@@ -1,0 +1,272 @@
+#!/usr/bin/env bash
+#
+# Validate Bjorn's clean stop and subsequent restart.
+
+set -Eeuo pipefail
+
+SERVICE_NAME="bjorn.service"
+TARGET_DIR="/home/bjorn/Bjorn"
+WEB_PORT=8000
+EXPECTED_HTTP="auto"
+STOP_TIMEOUT=30
+PORT_RELEASE_TIMEOUT=90
+ORIGINALLY_ACTIVE=0
+TEST_FINISHED=0
+
+usage() {
+    cat <<'EOF'
+Usage:
+  sudo ./tests/validate_scan_lifecycle.sh [options]
+
+Options:
+  --service UNIT         Systemd service (default: bjorn.service)
+  --target PATH          Live Bjorn directory (default: /home/bjorn/Bjorn)
+  --port PORT            Expected web port (default: 8000)
+  --expect-http CODE     Expected HTTP code: auto, 200, or 401 (default: auto)
+  --stop-timeout SEC     Maximum clean stop time (default: 30)
+  --port-timeout SEC     Maximum port-release wait (default: 90)
+  -h, --help             Show this help
+
+This test performs one real service stop and restart. On failure it attempts
+to return a service that was originally active to the active state.
+EOF
+}
+
+fail() {
+    echo "LIFECYCLE_FAIL: $*" >&2
+    exit 1
+}
+
+require_value() {
+    local option="$1"
+    local value="${2:-}"
+    [[ -n "$value" ]] || fail "$option requires a value"
+}
+
+require_positive_integer() {
+    local option="$1"
+    local value="$2"
+    [[ "$value" =~ ^[1-9][0-9]*$ ]] || \
+        fail "$option requires a positive integer"
+}
+
+while (($#)); do
+    case "$1" in
+        --service)
+            require_value "$1" "${2:-}"
+            SERVICE_NAME="$2"
+            shift 2
+            ;;
+        --target)
+            require_value "$1" "${2:-}"
+            TARGET_DIR="$2"
+            shift 2
+            ;;
+        --port)
+            require_value "$1" "${2:-}"
+            WEB_PORT="$2"
+            shift 2
+            ;;
+        --expect-http)
+            require_value "$1" "${2:-}"
+            EXPECTED_HTTP="$2"
+            shift 2
+            ;;
+        --stop-timeout)
+            require_value "$1" "${2:-}"
+            STOP_TIMEOUT="$2"
+            shift 2
+            ;;
+        --port-timeout)
+            require_value "$1" "${2:-}"
+            PORT_RELEASE_TIMEOUT="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            fail "unknown option: $1"
+            ;;
+    esac
+done
+
+[[ $EUID -eq 0 ]] || fail "run this lifecycle test with sudo"
+require_positive_integer "--port" "$WEB_PORT"
+require_positive_integer "--stop-timeout" "$STOP_TIMEOUT"
+require_positive_integer "--port-timeout" "$PORT_RELEASE_TIMEOUT"
+[[ "$EXPECTED_HTTP" == "auto" ||
+   "$EXPECTED_HTTP" == "200" ||
+   "$EXPECTED_HTTP" == "401" ]] || \
+    fail "--expect-http must be auto, 200, or 401"
+
+TARGET_DIR="$(readlink -f -- "$TARGET_DIR")"
+[[ -f "$TARGET_DIR/Bjorn.py" ]] || \
+    fail "Bjorn.py not found in target: $TARGET_DIR"
+systemctl cat "$SERVICE_NAME" >/dev/null || \
+    fail "service not found: $SERVICE_NAME"
+systemctl is-active --quiet "$SERVICE_NAME" || \
+    fail "service is not active: $SERVICE_NAME"
+ORIGINALLY_ACTIVE=1
+
+INITIAL_PID="$(systemctl show "$SERVICE_NAME" -p MainPID --value)"
+INITIAL_HTTP="$(
+    curl --silent --output /dev/null --write-out '%{http_code}' \
+        --max-time 2 "http://127.0.0.1:$WEB_PORT/" || true
+)"
+if [[ "$EXPECTED_HTTP" == "auto" ]]; then
+    [[ "$INITIAL_HTTP" == "200" || "$INITIAL_HTTP" == "401" ]] || \
+        fail "initial web response is HTTP $INITIAL_HTTP, expected 200 or 401"
+    EXPECTED_HTTP="$INITIAL_HTTP"
+elif [[ "$INITIAL_HTTP" != "$EXPECTED_HTTP" ]]; then
+    fail "initial web response is HTTP $INITIAL_HTTP, expected $EXPECTED_HTTP"
+fi
+
+wait_for_web_port_release() {
+    local webapp_file="$TARGET_DIR/webapp.py"
+    local second
+
+    if [[ -f "$webapp_file" ]] && \
+       grep -Eq 'allow_reuse_address[[:space:]]*=[[:space:]]*True' \
+           "$webapp_file"; then
+        return 0
+    fi
+
+    command -v ss >/dev/null || \
+        fail "ss is required to wait for port $WEB_PORT"
+    for ((second = 0; second <= PORT_RELEASE_TIMEOUT; second++)); do
+        if ! ss -Htan state time-wait "sport = :$WEB_PORT" |
+             grep -q . &&
+           ! ss -Hltn "sport = :$WEB_PORT" |
+             grep -q .; then
+            return 0
+        fi
+        if ((second % 5 == 0)); then
+            printf 'Waiting for port %s: %s/%ss\n' \
+                "$WEB_PORT" "$second" "$PORT_RELEASE_TIMEOUT"
+        fi
+        sleep 1
+    done
+    fail "port $WEB_PORT was not released within $PORT_RELEASE_TIMEOUT seconds"
+}
+
+start_and_wait() {
+    local second
+    local state
+    local status
+
+    wait_for_web_port_release
+    systemctl reset-failed "$SERVICE_NAME"
+    systemctl start "$SERVICE_NAME"
+    for ((second = 0; second < 45; second++)); do
+        state="$(systemctl is-active "$SERVICE_NAME" || true)"
+        status="$(
+            curl --silent --output /dev/null --write-out '%{http_code}' \
+                --max-time 2 "http://127.0.0.1:$WEB_PORT/" || true
+        )"
+        if [[ "$state" == "active" && "$status" == "$EXPECTED_HTTP" ]]; then
+            return 0
+        fi
+        sleep 1
+    done
+    fail "service did not return with HTTP $EXPECTED_HTTP on port $WEB_PORT"
+}
+
+recover_service() {
+    local exit_code=$?
+    local recover_http=""
+    local recover_state=""
+    local second
+
+    if ((exit_code != 0 && ORIGINALLY_ACTIVE == 1 && TEST_FINISHED == 0)); then
+        echo "Attempting to recover $SERVICE_NAME after test failure..." >&2
+        set +e
+        if ! systemctl is-active --quiet "$SERVICE_NAME"; then
+            wait_for_web_port_release
+            systemctl reset-failed "$SERVICE_NAME"
+            systemctl start "$SERVICE_NAME"
+        fi
+        for ((second = 0; second < 45; second++)); do
+            recover_state="$(systemctl is-active "$SERVICE_NAME" || true)"
+            recover_http="$(
+                curl --silent --output /dev/null --write-out '%{http_code}' \
+                    --max-time 2 "http://127.0.0.1:$WEB_PORT/" || true
+            )"
+            if [[ "$recover_state" == "active" &&
+                  "$recover_http" == "$EXPECTED_HTTP" ]]; then
+                echo "RECOVERY_OK SERVICE=$recover_state HTTP=$recover_http" >&2
+                break
+            fi
+            sleep 1
+        done
+        if [[ "$recover_state" != "active" ||
+              "$recover_http" != "$EXPECTED_HTTP" ]]; then
+            echo "RECOVERY_FAIL SERVICE=$recover_state HTTP=$recover_http" >&2
+        fi
+    fi
+    exit "$exit_code"
+}
+trap recover_service EXIT
+
+STOP_STARTED_AT="$(date '+%Y-%m-%d %H:%M:%S')"
+STOP_STARTED_SECONDS="$SECONDS"
+set +e
+systemctl stop "$SERVICE_NAME"
+STOP_COMMAND_RESULT=$?
+set -e
+STOP_DURATION="$((SECONDS - STOP_STARTED_SECONDS))"
+STOP_STATE="$(systemctl is-active "$SERVICE_NAME" || true)"
+STOP_SUBSTATE="$(systemctl show "$SERVICE_NAME" -p SubState --value)"
+STOP_RESULT="$(systemctl show "$SERVICE_NAME" -p Result --value)"
+
+if [[ "$STOP_STATE" != "inactive" ]]; then
+    echo "Stop diagnostics:" >&2
+    printf 'COMMAND_RESULT=%s STATE=%s SUBSTATE=%s RESULT=%s DURATION=%ss\n' \
+        "$STOP_COMMAND_RESULT" \
+        "$STOP_STATE" \
+        "$STOP_SUBSTATE" \
+        "$STOP_RESULT" \
+        "$STOP_DURATION" >&2
+    journalctl -u "$SERVICE_NAME" \
+        --since "$STOP_STARTED_AT" \
+        --no-pager \
+        -o cat |
+        tail -80 >&2
+    fail "service did not reach inactive state"
+fi
+((STOP_COMMAND_RESULT == 0)) || \
+    fail "systemctl stop returned $STOP_COMMAND_RESULT"
+((STOP_DURATION <= STOP_TIMEOUT)) || \
+    fail "service stop took ${STOP_DURATION}s, limit is ${STOP_TIMEOUT}s"
+if pgrep -f -- "$TARGET_DIR/Bjorn.py" >/dev/null; then
+    fail "Bjorn.py process remains after service stop"
+fi
+
+STOP_JOURNAL="$(mktemp)"
+journalctl -u "$SERVICE_NAME" --since "$STOP_STARTED_AT" --no-pager \
+    >"$STOP_JOURNAL"
+grep -q 'Main loop finished. Clean exit.' "$STOP_JOURNAL" || {
+    rm -f -- "$STOP_JOURNAL"
+    fail "clean-exit log entry was not found"
+}
+SHUTDOWN_ERROR_PATTERN='Fatal Python error|Traceback|Exception in thread|status=[0-9]+/ABRT|Failed with result|Main process exited|timed out'
+if grep -qiE "$SHUTDOWN_ERROR_PATTERN" "$STOP_JOURNAL"; then
+    echo "Relevant shutdown errors:" >&2
+    grep -iE "$SHUTDOWN_ERROR_PATTERN" "$STOP_JOURNAL" >&2 || true
+    rm -f -- "$STOP_JOURNAL"
+    fail "shutdown errors found in journal"
+fi
+rm -f -- "$STOP_JOURNAL"
+
+start_and_wait
+RESTARTED_PID="$(systemctl show "$SERVICE_NAME" -p MainPID --value)"
+[[ "$RESTARTED_PID" =~ ^[1-9][0-9]*$ ]] || \
+    fail "invalid restarted service PID: $RESTARTED_PID"
+[[ "$RESTARTED_PID" != "$INITIAL_PID" ]] || \
+    fail "service PID did not change across stop/start"
+
+TEST_FINISHED=1
+trap - EXIT
+printf 'LIFECYCLE_OK STOP_DURATION=%ss OLD_PID=%s NEW_PID=%s HTTP=%s\n' \
+    "$STOP_DURATION" "$INITIAL_PID" "$RESTARTED_PID" "$EXPECTED_HTTP"

--- a/tests/validate_scan_runtime.sh
+++ b/tests/validate_scan_runtime.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+#
+# Validate a running Bjorn scanner without restarting the service.
+
+set -Eeuo pipefail
+
+SERVICE_NAME="bjorn.service"
+WEB_PORT=8000
+DURATION=30
+SCAN_TIMEOUT=90
+THREAD_LIMIT=64
+EXPECTED_HTTP="auto"
+
+usage() {
+    cat <<'EOF'
+Usage:
+  sudo ./tests/validate_scan_runtime.sh [options]
+
+Options:
+  --service UNIT       Systemd service (default: bjorn.service)
+  --port PORT          Expected web port (default: 8000)
+  --duration SECONDS   Observation time (default: 30)
+  --scan-timeout SEC   Maximum time from test start for one scan (default: 90)
+  --thread-limit N     Fail above this process thread count (default: 64)
+  --expect-http CODE   Expected HTTP code: auto, 200, or 401 (default: auto)
+  -h, --help           Show this help
+
+The test keeps the service running and verifies a stable PID, HTTP response,
+bounded process thread count, at least one completed scan for the current
+process, and absence of scanner/thread-pool errors in its journal.
+EOF
+}
+
+fail() {
+    echo "RUNTIME_FAIL: $*" >&2
+    exit 1
+}
+
+require_value() {
+    local option="$1"
+    local value="${2:-}"
+    [[ -n "$value" ]] || fail "$option requires a value"
+}
+
+require_positive_integer() {
+    local option="$1"
+    local value="$2"
+    [[ "$value" =~ ^[1-9][0-9]*$ ]] || \
+        fail "$option requires a positive integer"
+}
+
+while (($#)); do
+    case "$1" in
+        --service)
+            require_value "$1" "${2:-}"
+            SERVICE_NAME="$2"
+            shift 2
+            ;;
+        --port)
+            require_value "$1" "${2:-}"
+            WEB_PORT="$2"
+            shift 2
+            ;;
+        --duration)
+            require_value "$1" "${2:-}"
+            DURATION="$2"
+            shift 2
+            ;;
+        --scan-timeout)
+            require_value "$1" "${2:-}"
+            SCAN_TIMEOUT="$2"
+            shift 2
+            ;;
+        --thread-limit)
+            require_value "$1" "${2:-}"
+            THREAD_LIMIT="$2"
+            shift 2
+            ;;
+        --expect-http)
+            require_value "$1" "${2:-}"
+            EXPECTED_HTTP="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            fail "unknown option: $1"
+            ;;
+    esac
+done
+
+[[ $EUID -eq 0 ]] || fail "run this runtime test with sudo"
+require_positive_integer "--port" "$WEB_PORT"
+require_positive_integer "--duration" "$DURATION"
+require_positive_integer "--scan-timeout" "$SCAN_TIMEOUT"
+require_positive_integer "--thread-limit" "$THREAD_LIMIT"
+((SCAN_TIMEOUT >= DURATION)) || \
+    fail "--scan-timeout must be greater than or equal to --duration"
+[[ "$EXPECTED_HTTP" == "auto" ||
+   "$EXPECTED_HTTP" == "200" ||
+   "$EXPECTED_HTTP" == "401" ]] || \
+    fail "--expect-http must be auto, 200, or 401"
+
+systemctl cat "$SERVICE_NAME" >/dev/null || \
+    fail "service not found: $SERVICE_NAME"
+systemctl is-active --quiet "$SERVICE_NAME" || \
+    fail "service is not active: $SERVICE_NAME"
+
+SERVICE_PID="$(systemctl show "$SERVICE_NAME" -p MainPID --value)"
+[[ "$SERVICE_PID" =~ ^[1-9][0-9]*$ ]] || \
+    fail "invalid service PID: $SERVICE_PID"
+kill -0 "$SERVICE_PID" 2>/dev/null || \
+    fail "service PID is not running: $SERVICE_PID"
+
+INITIAL_HTTP="$(
+    curl --silent --output /dev/null --write-out '%{http_code}' \
+        --max-time 2 "http://127.0.0.1:$WEB_PORT/" || true
+)"
+if [[ "$EXPECTED_HTTP" == "auto" ]]; then
+    [[ "$INITIAL_HTTP" == "200" || "$INITIAL_HTTP" == "401" ]] || \
+        fail "initial web response is HTTP $INITIAL_HTTP, expected 200 or 401"
+    EXPECTED_HTTP="$INITIAL_HTTP"
+elif [[ "$INITIAL_HTTP" != "$EXPECTED_HTTP" ]]; then
+    fail "initial web response is HTTP $INITIAL_HTTP, expected $EXPECTED_HTTP"
+fi
+
+MAX_THREADS=0
+check_runtime_sample() {
+    CURRENT_STATE="$(systemctl is-active "$SERVICE_NAME" || true)"
+    CURRENT_PID="$(systemctl show "$SERVICE_NAME" -p MainPID --value)"
+    CURRENT_HTTP="$(
+        curl --silent --output /dev/null --write-out '%{http_code}' \
+            --max-time 2 "http://127.0.0.1:$WEB_PORT/" || true
+    )"
+    CURRENT_THREADS="$(
+        ps -o nlwp= -p "$SERVICE_PID" 2>/dev/null |
+            tr -d '[:space:]'
+    )"
+
+    [[ "$CURRENT_STATE" == "active" ]] || \
+        fail "service state changed to: $CURRENT_STATE"
+    [[ "$CURRENT_PID" == "$SERVICE_PID" ]] || \
+        fail "service PID changed from $SERVICE_PID to $CURRENT_PID"
+    [[ "$CURRENT_HTTP" == "$EXPECTED_HTTP" ]] || \
+        fail "web response changed from HTTP $EXPECTED_HTTP to $CURRENT_HTTP"
+    [[ "$CURRENT_THREADS" =~ ^[1-9][0-9]*$ ]] || \
+        fail "could not read thread count for PID $SERVICE_PID"
+    ((CURRENT_THREADS <= THREAD_LIMIT)) || \
+        fail "thread limit exceeded: $CURRENT_THREADS > $THREAD_LIMIT"
+
+    if ((CURRENT_THREADS > MAX_THREADS)); then
+        MAX_THREADS="$CURRENT_THREADS"
+    fi
+}
+
+for ((second = 1; second <= DURATION; second++)); do
+    check_runtime_sample
+    printf '\rRuntime: %02d/%ss | Threads: %s | Maximum: %s' \
+        "$second" "$DURATION" "$CURRENT_THREADS" "$MAX_THREADS"
+    sleep 1
+done
+echo
+
+completed_scan_count() {
+    journalctl "_PID=$SERVICE_PID" --no-pager |
+        grep -c 'Scan results cleaned up' || true
+}
+
+COMPLETED_SCANS="$(completed_scan_count)"
+if ! [[ "$COMPLETED_SCANS" =~ ^[1-9][0-9]*$ ]]; then
+    for ((second = DURATION + 1; second <= SCAN_TIMEOUT; second++)); do
+        check_runtime_sample
+        COMPLETED_SCANS="$(completed_scan_count)"
+        printf '\rWaiting for scan completion: %02d/%ss | Threads: %s | Maximum: %s' \
+            "$second" "$SCAN_TIMEOUT" "$CURRENT_THREADS" "$MAX_THREADS"
+        if [[ "$COMPLETED_SCANS" =~ ^[1-9][0-9]*$ ]]; then
+            break
+        fi
+        sleep 1
+    done
+    echo
+fi
+
+JOURNAL_FILE="$(mktemp)"
+trap 'rm -f -- "$JOURNAL_FILE"' EXIT
+journalctl "_PID=$SERVICE_PID" --no-pager >"$JOURNAL_FILE"
+
+ERROR_PATTERN='cannot schedule|can.t start new thread|pthread_create|Error in scan|Fatal Python error|Traceback|Exception in thread|status=[0-9]+/ABRT'
+if grep -qiE "$ERROR_PATTERN" "$JOURNAL_FILE"; then
+    echo "Relevant journal errors:" >&2
+    grep -iE "$ERROR_PATTERN" "$JOURNAL_FILE" >&2 || true
+    fail "scanner or thread-pool errors found for PID $SERVICE_PID"
+fi
+
+COMPLETED_SCANS="$(grep -c 'Scan results cleaned up' "$JOURNAL_FILE" || true)"
+RESULT_WRITES="$(
+    grep -c 'Results saved to' "$JOURNAL_FILE" || true
+)"
+[[ "$COMPLETED_SCANS" =~ ^[1-9][0-9]*$ ]] || \
+    fail "no completed scan found for PID $SERVICE_PID"
+[[ "$RESULT_WRITES" =~ ^[1-9][0-9]*$ ]] || \
+    fail "no saved scan result found for PID $SERVICE_PID"
+
+printf 'RUNTIME_OK PID=%s HTTP=%s MAX_THREADS=%s COMPLETED_SCANS=%s\n' \
+    "$SERVICE_PID" "$EXPECTED_HTTP" "$MAX_THREADS" "$COMPLETED_SCANS"

--- a/tests/validate_scan_runtime.sh
+++ b/tests/validate_scan_runtime.sh
@@ -187,7 +187,7 @@ JOURNAL_FILE="$(mktemp)"
 trap 'rm -f -- "$JOURNAL_FILE"' EXIT
 journalctl "_PID=$SERVICE_PID" --no-pager >"$JOURNAL_FILE"
 
-ERROR_PATTERN='cannot schedule|can.t start new thread|pthread_create|Error in scan|Fatal Python error|Traceback|Exception in thread|status=[0-9]+/ABRT'
+ERROR_PATTERN='cannot schedule|can.t start new thread|pthread_create|Error in scan|Error updating livestatus|Error in (read_csv|calculate_open_ports|calculate_hosts_counts|save_results)|Fatal Python error|Traceback|Exception in thread|status=[0-9]+/ABRT'
 if grep -qiE "$ERROR_PATTERN" "$JOURNAL_FILE"; then
     echo "Relevant journal errors:" >&2
     grep -iE "$ERROR_PATTERN" "$JOURNAL_FILE" >&2 || true

--- a/tests/validate_web_auth_runtime.sh
+++ b/tests/validate_web_auth_runtime.sh
@@ -1,0 +1,288 @@
+#!/usr/bin/env bash
+#
+# Validate Bjorn web authentication against a live local service.
+
+set -Eeuo pipefail
+
+TARGET_DIR="/home/bjorn/Bjorn"
+SERVICE_NAME="bjorn.service"
+COMMAND_PATH="/usr/local/sbin/http_auth"
+WEB_PORT=8000
+TEST_USERNAME="bjorn-validation"
+TEMP_DIR=""
+CREDENTIAL_BACKUP=""
+CREDENTIAL_FILE=""
+RESTORE_PENDING=0
+
+usage() {
+    cat <<'EOF'
+Usage:
+  sudo ./tests/validate_web_auth_runtime.sh [options]
+
+Options:
+  --target PATH       Live Bjorn directory (default: /home/bjorn/Bjorn)
+  --service UNIT      Systemd service (default: bjorn.service)
+  --command PATH      Management command (default: /usr/local/sbin/http_auth)
+  --port PORT         Web port (default: 8000)
+  -h, --help          Show this help
+
+The test temporarily replaces the credential verifier, exercises set, status,
+disable, and enable, checks authenticated and unauthenticated HTTP requests,
+performs an incomplete-POST regression test and restores the original verifier
+on success, failure, or interruption. No plaintext password is printed or
+stored in the Bjorn configuration.
+EOF
+}
+
+fail() {
+    echo "WEB_AUTH_RUNTIME_FAIL: $*" >&2
+    exit 1
+}
+
+require_value() {
+    local option="$1"
+    local value="${2:-}"
+    [[ -n "$value" ]] || fail "$option requires a value"
+}
+
+while (($#)); do
+    case "$1" in
+        --target)
+            require_value "$1" "${2:-}"
+            TARGET_DIR="$2"
+            shift 2
+            ;;
+        --service)
+            require_value "$1" "${2:-}"
+            SERVICE_NAME="$2"
+            shift 2
+            ;;
+        --command)
+            require_value "$1" "${2:-}"
+            COMMAND_PATH="$2"
+            shift 2
+            ;;
+        --port)
+            require_value "$1" "${2:-}"
+            WEB_PORT="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            fail "unknown option: $1"
+            ;;
+    esac
+done
+
+[[ $EUID -eq 0 ]] || fail "run this runtime test with sudo"
+[[ "$WEB_PORT" =~ ^[1-9][0-9]*$ ]] || \
+    fail "--port requires a positive integer"
+
+TARGET_DIR="$(readlink -f -- "$TARGET_DIR")"
+COMMAND_PATH="$(readlink -f -- "$COMMAND_PATH")"
+CREDENTIAL_FILE="$TARGET_DIR/config/web_auth.json"
+
+[[ -x "$COMMAND_PATH" ]] || \
+    fail "management command is not executable: $COMMAND_PATH"
+[[ -f "$TARGET_DIR/web_auth.py" ]] || \
+    fail "web_auth.py not found in target: $TARGET_DIR"
+[[ -f "$CREDENTIAL_FILE" ]] || \
+    fail "credential verifier not found: $CREDENTIAL_FILE"
+systemctl is-active --quiet "$SERVICE_NAME" || \
+    fail "service is not active: $SERVICE_NAME"
+
+SERVICE_PID="$(systemctl show "$SERVICE_NAME" -p MainPID --value)"
+[[ "$SERVICE_PID" =~ ^[1-9][0-9]*$ ]] || \
+    fail "invalid service PID: $SERVICE_PID"
+INITIAL_HTTP="$(
+    curl --silent --output /dev/null --write-out '%{http_code}' \
+        --max-time 2 "http://127.0.0.1:$WEB_PORT/" || true
+)"
+[[ "$INITIAL_HTTP" == "200" || "$INITIAL_HTTP" == "401" ]] || \
+    fail "initial web response is HTTP $INITIAL_HTTP"
+
+TEMP_DIR="$(mktemp -d)"
+CREDENTIAL_BACKUP="$TEMP_DIR/web_auth.json.original"
+cp -a -- "$CREDENTIAL_FILE" "$CREDENTIAL_BACKUP"
+RESTORE_PENDING=1
+
+restore_credentials() {
+    if ((RESTORE_PENDING == 1)); then
+        rm -f -- "$CREDENTIAL_FILE"
+        cp -a -- "$CREDENTIAL_BACKUP" "$CREDENTIAL_FILE"
+        RESTORE_PENDING=0
+    fi
+}
+
+cleanup() {
+    restore_credentials
+    if [[ -n "$TEMP_DIR" && -d "$TEMP_DIR" ]]; then
+        rm -f -- \
+            "$TEMP_DIR/web_auth.json.original" \
+            "$TEMP_DIR/curl-valid.conf" \
+            "$TEMP_DIR/curl-wrong.conf" \
+            "$TEMP_DIR/journal.log"
+        rmdir -- "$TEMP_DIR" 2>/dev/null || true
+    fi
+}
+
+trap cleanup EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+TEST_STARTED_AT="$(date '+%Y-%m-%d %H:%M:%S')"
+TEST_PASSWORD="$(
+    python3 -c 'import secrets; print(secrets.token_urlsafe(32))'
+)"
+
+printf '%s\n' "$TEST_PASSWORD" |
+    "$COMMAND_PATH" set "$TEST_USERNAME" --password-stdin >/dev/null
+
+STATUS_OUTPUT="$("$COMMAND_PATH" status)"
+grep -q 'Credentials configured: yes' <<<"$STATUS_OUTPUT" || \
+    fail "status did not report configured credentials"
+grep -q 'Authentication enabled: yes' <<<"$STATUS_OUTPUT" || \
+    fail "status did not report enabled authentication"
+echo "COMMAND_SET_STATUS_OK"
+
+VALID_CURL_CONFIG="$TEMP_DIR/curl-valid.conf"
+WRONG_CURL_CONFIG="$TEMP_DIR/curl-wrong.conf"
+printf 'user = "%s:%s"\n' \
+    "$TEST_USERNAME" "$TEST_PASSWORD" >"$VALID_CURL_CONFIG"
+printf 'user = "%s:%s"\n' \
+    "$TEST_USERNAME" "definitely-wrong-password" >"$WRONG_CURL_CONFIG"
+chmod 600 "$VALID_CURL_CONFIG" "$WRONG_CURL_CONFIG"
+
+UNAUTHENTICATED_HTTP="$(
+    curl --silent --output /dev/null --write-out '%{http_code}' \
+        --max-time 2 "http://127.0.0.1:$WEB_PORT/" || true
+)"
+VALID_HTTP="$(
+    curl --config "$VALID_CURL_CONFIG" \
+        --silent --output /dev/null --write-out '%{http_code}' \
+        --max-time 2 "http://127.0.0.1:$WEB_PORT/" || true
+)"
+WRONG_HTTP="$(
+    curl --config "$WRONG_CURL_CONFIG" \
+        --silent --output /dev/null --write-out '%{http_code}' \
+        --max-time 2 "http://127.0.0.1:$WEB_PORT/" || true
+)"
+PRIVATE_HTTP="$(
+    curl --config "$VALID_CURL_CONFIG" \
+        --silent --output /dev/null --write-out '%{http_code}' \
+        --max-time 2 \
+        "http://127.0.0.1:$WEB_PORT/config/web_auth.json" || true
+)"
+
+[[ "$UNAUTHENTICATED_HTTP" == "401" ]] || \
+    fail "headerless request returned HTTP $UNAUTHENTICATED_HTTP"
+[[ "$VALID_HTTP" == "200" ]] || \
+    fail "valid credentials returned HTTP $VALID_HTTP"
+[[ "$WRONG_HTTP" == "401" ]] || \
+    fail "wrong credentials returned HTTP $WRONG_HTTP"
+[[ "$PRIVATE_HTTP" == "404" ]] || \
+    fail "private credential path returned HTTP $PRIVATE_HTTP"
+echo "HTTP_AUTHORIZATION_OK"
+
+"$COMMAND_PATH" disable >/dev/null
+DISABLED_STATUS="$("$COMMAND_PATH" status)"
+grep -q 'Authentication enabled: no' <<<"$DISABLED_STATUS" || \
+    fail "disable command did not update status"
+DISABLED_HTTP="$(
+    curl --silent --output /dev/null --write-out '%{http_code}' \
+        --max-time 2 "http://127.0.0.1:$WEB_PORT/" || true
+)"
+[[ "$DISABLED_HTTP" == "200" ]] || \
+    fail "disabled authentication returned HTTP $DISABLED_HTTP"
+
+"$COMMAND_PATH" enable >/dev/null
+ENABLED_STATUS="$("$COMMAND_PATH" status)"
+grep -q 'Authentication enabled: yes' <<<"$ENABLED_STATUS" || \
+    fail "enable command did not update status"
+ENABLED_HTTP="$(
+    curl --silent --output /dev/null --write-out '%{http_code}' \
+        --max-time 2 "http://127.0.0.1:$WEB_PORT/" || true
+)"
+[[ "$ENABLED_HTTP" == "401" ]] || \
+    fail "re-enabled authentication returned HTTP $ENABLED_HTTP"
+echo "COMMAND_DISABLE_ENABLE_OK"
+
+for _ in {1..30}; do
+    STRESS_HTTP="$(
+        curl --silent --output /dev/null --write-out '%{http_code}' \
+            --max-time 2 "http://127.0.0.1:$WEB_PORT/" || true
+    )"
+    [[ "$STRESS_HTTP" == "401" ]] || \
+        fail "challenge stress request returned HTTP $STRESS_HTTP"
+done
+echo "HEADERLESS_CHALLENGE_STRESS_OK requests=30"
+
+python3 - "$WEB_PORT" <<'PY'
+import socket
+import sys
+import time
+
+port = int(sys.argv[1])
+headers = (
+    "POST /save_config HTTP/1.1\r\n"
+    f"Host: 127.0.0.1:{port}\r\n"
+    "Content-Type: application/json\r\n"
+    "Content-Length: 1048576\r\n"
+    "Connection: keep-alive\r\n"
+    "\r\n"
+).encode("ascii")
+
+started = time.monotonic()
+with socket.create_connection(("127.0.0.1", port), timeout=2) as client:
+    client.settimeout(2)
+    client.sendall(headers)
+    response = client.recv(4096)
+elapsed = time.monotonic() - started
+
+if b" 401 " not in response:
+    raise SystemExit("incomplete POST did not receive HTTP 401")
+if b"Connection: close\r\n" not in response:
+    raise SystemExit("incomplete POST response did not close the connection")
+if elapsed >= 2:
+    raise SystemExit(f"incomplete POST response took {elapsed:.3f}s")
+print(f"INCOMPLETE_POST_OK elapsed={elapsed:.3f}s")
+PY
+
+[[ "$(systemctl is-active "$SERVICE_NAME" || true)" == "active" ]] || \
+    fail "service stopped during runtime validation"
+CURRENT_PID="$(systemctl show "$SERVICE_NAME" -p MainPID --value)"
+[[ "$CURRENT_PID" == "$SERVICE_PID" ]] || \
+    fail "service PID changed from $SERVICE_PID to $CURRENT_PID"
+
+JOURNAL_FILE="$TEMP_DIR/journal.log"
+journalctl "_PID=$SERVICE_PID" \
+    --since "$TEST_STARTED_AT" \
+    --no-pager \
+    -o cat >"$JOURNAL_FILE"
+ERROR_PATTERN='Fatal Python error|Traceback|Exception in thread|Unexpected web server thread error|can.t start new thread'
+if grep -qiE "$ERROR_PATTERN" "$JOURNAL_FILE"; then
+    grep -iE "$ERROR_PATTERN" "$JOURNAL_FILE" >&2 || true
+    fail "web or thread errors found in journal"
+fi
+INVALID_WARNING_COUNT="$(
+    grep -c 'Rejected invalid web credentials' "$JOURNAL_FILE" || true
+)"
+[[ "$INVALID_WARNING_COUNT" =~ ^[1-9][0-9]*$ ]] || \
+    fail "invalid credentials were not recorded in the journal"
+echo "JOURNAL_AUDIT_OK invalid_warnings=$INVALID_WARNING_COUNT"
+
+restore_credentials
+RESTORED_HTTP="$(
+    curl --silent --output /dev/null --write-out '%{http_code}' \
+        --max-time 2 "http://127.0.0.1:$WEB_PORT/" || true
+)"
+[[ "$RESTORED_HTTP" == "$INITIAL_HTTP" ]] || \
+    fail "restored credentials returned HTTP $RESTORED_HTTP, expected $INITIAL_HTTP"
+
+echo "CREDENTIAL_RESTORE_OK HTTP=$RESTORED_HTTP"
+printf 'WEB_AUTH_RUNTIME_OK PID=%s INITIAL_HTTP=%s\n' \
+    "$SERVICE_PID" "$INITIAL_HTTP"

--- a/web_auth.py
+++ b/web_auth.py
@@ -210,10 +210,16 @@ class CredentialStore:
         return username_matches and password_matches
 
     def file_signature(self):
-        """Return a signature that changes when credentials are replaced."""
+        """Return a signature that changes with content or access metadata."""
         try:
             stat_result = self.path.stat()
-            return stat_result.st_mtime_ns, stat_result.st_size
+            return (
+                stat_result.st_mtime_ns,
+                stat_result.st_size,
+                stat_result.st_mode,
+                stat_result.st_uid,
+                stat_result.st_gid,
+            )
         except OSError:
             return None
 

--- a/web_auth.py
+++ b/web_auth.py
@@ -1,0 +1,296 @@
+"""Optional HTTP Basic authentication for Bjorn's web interface."""
+
+import base64
+import binascii
+import hashlib
+import hmac
+import json
+import os
+import posixpath
+import tempfile
+import threading
+import time
+from pathlib import Path
+from urllib.parse import unquote, urlsplit
+
+
+class CredentialError(ValueError):
+    """Raised when credentials cannot be created or updated safely."""
+
+
+class CredentialStore:
+    """Store a salted password verifier without persisting plaintext secrets."""
+
+    VERSION = 1
+    ALGORITHM = "scrypt"
+    SCRYPT_N = 2**14
+    SCRYPT_R = 8
+    SCRYPT_P = 1
+    KEY_LENGTH = 32
+
+    def __init__(self, path):
+        self.path = Path(path)
+
+    @staticmethod
+    def validate_username(username):
+        """Validate a Basic authentication username."""
+        if not isinstance(username, str):
+            raise CredentialError("Username must be a string.")
+        if not 1 <= len(username) <= 64:
+            raise CredentialError("Username must contain between 1 and 64 characters.")
+        if ":" in username or any(ord(char) < 33 or ord(char) > 126 for char in username):
+            raise CredentialError(
+                "Username must use printable ASCII characters except ':'."
+            )
+
+    @staticmethod
+    def validate_password(password):
+        """Require a reasonable minimum password length."""
+        if not isinstance(password, str) or len(password) < 12:
+            raise CredentialError("Password must contain at least 12 characters.")
+
+    @classmethod
+    def _derive_key(cls, password, salt, parameters=None):
+        parameters = parameters or {
+            "n": cls.SCRYPT_N,
+            "r": cls.SCRYPT_R,
+            "p": cls.SCRYPT_P,
+        }
+        return hashlib.scrypt(
+            password.encode("utf-8"),
+            salt=salt,
+            n=parameters["n"],
+            r=parameters["r"],
+            p=parameters["p"],
+            dklen=cls.KEY_LENGTH,
+        )
+
+    def _write_record(self, record):
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        file_descriptor, temporary_path = tempfile.mkstemp(
+            prefix=f".{self.path.name}.",
+            dir=self.path.parent,
+            text=True,
+        )
+        try:
+            with os.fdopen(file_descriptor, "w", encoding="utf-8") as handle:
+                json.dump(record, handle, indent=2)
+                handle.write("\n")
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.chmod(temporary_path, 0o600)
+            os.replace(temporary_path, self.path)
+        finally:
+            if os.path.exists(temporary_path):
+                os.unlink(temporary_path)
+
+    def save(self, username, password, enabled=True):
+        """Create or replace credentials and enable protection by default."""
+        self.validate_username(username)
+        self.validate_password(password)
+        salt = os.urandom(16)
+        password_hash = self._derive_key(password, salt)
+        record = {
+            "version": self.VERSION,
+            "enabled": bool(enabled),
+            "username": username,
+            "algorithm": self.ALGORITHM,
+            "salt": base64.b64encode(salt).decode("ascii"),
+            "password_hash": base64.b64encode(password_hash).decode("ascii"),
+            "scrypt": {
+                "n": self.SCRYPT_N,
+                "r": self.SCRYPT_R,
+                "p": self.SCRYPT_P,
+            },
+        }
+        self._write_record(record)
+
+    def _load(self):
+        with self.path.open(encoding="utf-8") as handle:
+            record = json.load(handle)
+
+        if not isinstance(record, dict):
+            raise CredentialError("Credential file must contain a JSON object.")
+        if record.get("version") != self.VERSION:
+            raise CredentialError("Unsupported credential file version.")
+        if record.get("algorithm") != self.ALGORITHM:
+            raise CredentialError("Unsupported password hashing algorithm.")
+        self.validate_username(record.get("username"))
+
+        parameters = record.get("scrypt", {})
+        if not isinstance(parameters, dict):
+            raise CredentialError("Invalid scrypt parameters.")
+        try:
+            n = int(parameters.get("n", 0))
+            r = int(parameters.get("r", 0))
+            p = int(parameters.get("p", 0))
+        except (TypeError, ValueError) as exc:
+            raise CredentialError("Invalid scrypt parameters.") from exc
+        if n < 2**14 or n > 2**20 or n & (n - 1):
+            raise CredentialError("Invalid scrypt N parameter.")
+        if not 1 <= r <= 32 or not 1 <= p <= 16:
+            raise CredentialError("Invalid scrypt work parameters.")
+
+        try:
+            salt = base64.b64decode(record["salt"], validate=True)
+            password_hash = base64.b64decode(
+                record["password_hash"],
+                validate=True,
+            )
+        except (KeyError, binascii.Error, TypeError) as exc:
+            raise CredentialError("Invalid credential encoding.") from exc
+
+        if len(salt) < 16 or len(password_hash) != self.KEY_LENGTH:
+            raise CredentialError("Invalid credential lengths.")
+
+        record["_salt"] = salt
+        record["_password_hash"] = password_hash
+        record["_parameters"] = {"n": n, "r": r, "p": p}
+        return record
+
+    def auth_required(self):
+        """Return whether authentication is required, failing closed on corruption."""
+        if not self.path.exists():
+            return False
+        try:
+            return bool(self._load().get("enabled", False))
+        except (CredentialError, OSError, json.JSONDecodeError):
+            return True
+
+    def is_configured(self):
+        """Return whether the credential file contains a valid verifier."""
+        try:
+            self._load()
+            return True
+        except (CredentialError, OSError, json.JSONDecodeError):
+            return False
+
+    def set_enabled(self, enabled):
+        """Enable or disable an existing valid credential record."""
+        try:
+            record = self._load()
+        except (OSError, json.JSONDecodeError) as exc:
+            raise CredentialError("No valid credentials are configured.") from exc
+
+        for transient_key in (
+            "_salt",
+            "_password_hash",
+            "_parameters",
+        ):
+            record.pop(transient_key, None)
+        record["enabled"] = bool(enabled)
+        self._write_record(record)
+
+    def verify(self, username, password):
+        """Verify a username and password using constant-time comparisons."""
+        try:
+            record = self._load()
+            candidate = self._derive_key(
+                password,
+                record["_salt"],
+                record["_parameters"],
+            )
+        except (
+            CredentialError,
+            OSError,
+            TypeError,
+            ValueError,
+            json.JSONDecodeError,
+        ):
+            return False
+
+        username_matches = hmac.compare_digest(
+            username.encode("utf-8"),
+            record["username"].encode("utf-8"),
+        )
+        password_matches = hmac.compare_digest(
+            candidate,
+            record["_password_hash"],
+        )
+        return username_matches and password_matches
+
+    def file_signature(self):
+        """Return a signature that changes when credentials are replaced."""
+        try:
+            stat_result = self.path.stat()
+            return stat_result.st_mtime_ns, stat_result.st_size
+        except OSError:
+            return None
+
+
+def is_credential_file_request(request_target):
+    """Recognize the private credential path after URL normalization."""
+    if "://" in request_target:
+        request_path = urlsplit(request_target).path
+    else:
+        request_path = request_target.partition("?")[0].partition("#")[0]
+    request_path = unquote(request_path).replace("\\", "/")
+    normalized_path = "/" + posixpath.normpath(request_path).lstrip("/")
+    return normalized_path == "/config/web_auth.json"
+
+
+class BasicAuthGate:
+    """Parse an Authorization header and verify it against a credential store."""
+
+    def __init__(self, credential_store, cache_seconds=30):
+        self.credential_store = credential_store
+        self.cache_seconds = cache_seconds
+        self._cache_lock = threading.Lock()
+        self._cached_header_digest = None
+        self._cached_file_signature = None
+        self._cache_expires = 0
+
+    @staticmethod
+    def _decode_header(authorization_header):
+        """Return a username/password tuple from a valid Basic header."""
+        if not authorization_header:
+            return None
+
+        scheme, separator, encoded = authorization_header.partition(" ")
+        if separator != " " or scheme.lower() != "basic" or not encoded:
+            return None
+
+        try:
+            decoded = base64.b64decode(encoded, validate=True).decode("utf-8")
+        except (binascii.Error, UnicodeDecodeError):
+            return None
+
+        username, separator, password = decoded.partition(":")
+        if not separator:
+            return None
+        return username, password
+
+    def is_authorized(self, authorization_header):
+        """Return whether a Basic Authorization header is valid."""
+        if not authorization_header:
+            return False
+
+        header_digest = hashlib.sha256(
+            authorization_header.encode("utf-8")
+        ).digest()
+        file_signature = self.credential_store.file_signature()
+        with self._cache_lock:
+            cache_matches = (
+                self._cached_header_digest is not None
+                and hmac.compare_digest(
+                    header_digest,
+                    self._cached_header_digest,
+                )
+                and file_signature == self._cached_file_signature
+                and time.monotonic() < self._cache_expires
+            )
+        if cache_matches:
+            return True
+
+        credentials = self._decode_header(authorization_header)
+        if credentials is None:
+            return False
+        username, password = credentials
+        if not self.credential_store.verify(username, password):
+            return False
+
+        with self._cache_lock:
+            self._cached_header_digest = header_digest
+            self._cached_file_signature = file_signature
+            self._cache_expires = time.monotonic() + self.cache_seconds
+        return True

--- a/webapp.py
+++ b/webapp.py
@@ -292,12 +292,21 @@ class WebThread(threading.Thread):
 
     def shutdown(self):
         """
-        Shutdown the web server gracefully.
+        Request the manual server loop to exit and close its listening socket.
+
+        ``BaseServer.shutdown()`` may only be used with ``serve_forever()``.
+        This thread deliberately uses ``handle_request()`` so it can observe
+        Bjorn's shared shutdown flag; calling ``shutdown()`` here would wait
+        forever for a ``serve_forever()`` completion event that cannot occur.
         """
-        if self.httpd:
-            self.httpd.shutdown()
-            self.httpd.server_close()
-            logger.info("Web server shutdown initiated.")
+        self.shared_data.webapp_should_exit = True
+        httpd = self.httpd
+        if httpd:
+            try:
+                httpd.server_close()
+            except OSError:
+                pass
+        logger.info("Web server shutdown requested.")
 
 def handle_exit_web(signum, frame):
     """

--- a/webapp.py
+++ b/webapp.py
@@ -12,17 +12,33 @@ import io
 from logger import Logger
 from init_shared import shared_data
 from utils import WebUtils
+from web_auth import (
+    BasicAuthGate,
+    CredentialStore,
+    is_credential_file_request,
+)
 
 # Initialize the logger
 logger = Logger(name="webapp.py", level=logging.DEBUG)
 
 # Set the path to the favicon
 favicon_path = os.path.join(shared_data.webdir, '/images/favicon.ico')
+credential_store = CredentialStore(shared_data.web_auth_file)
+auth_gate = BasicAuthGate(credential_store)
+
+
+class ReusableTCPServer(socketserver.TCPServer):
+    """TCP server that can reclaim the configured port after a restart."""
+
+    allow_reuse_address = True
+
 
 class CustomHandler(http.server.SimpleHTTPRequestHandler):
     def __init__(self, *args, **kwargs):
         self.shared_data = shared_data
         self.web_utils = WebUtils(shared_data, logger)
+        self.credential_store = credential_store
+        self.auth_gate = auth_gate
         super().__init__(*args, **kwargs)
 
     def log_message(self, format, *args):
@@ -56,8 +72,80 @@ class CustomHandler(http.server.SimpleHTTPRequestHandler):
             content = file.read()
         self.send_gzipped_response(content, content_type)
 
+    def is_private_file_request(self):
+        """Prevent the credential verifier from being served as a static file."""
+        return is_credential_file_request(self.path)
+
+    def discard_available_request_body(self, limit=1024 * 1024):
+        """Drain only body bytes that are already available without waiting."""
+        try:
+            content_length = int(self.headers.get("Content-Length", 0))
+        except (TypeError, ValueError):
+            content_length = 0
+        remaining = min(max(content_length, 0), limit)
+        if remaining == 0:
+            return
+
+        original_timeout = self.connection.gettimeout()
+        self.connection.setblocking(False)
+        try:
+            while remaining:
+                try:
+                    available = self.rfile.peek(min(remaining, 64 * 1024))
+                except (BlockingIOError, OSError):
+                    break
+                if not available:
+                    break
+                chunk = self.rfile.read(min(remaining, len(available)))
+                if not chunk:
+                    break
+                remaining -= len(chunk)
+        finally:
+            self.connection.settimeout(original_timeout)
+
+    def require_authorization(self, send_body=True):
+        """Apply optional Basic authentication to every web route."""
+        if self.is_private_file_request():
+            if send_body:
+                self.send_error(404)
+            else:
+                self.send_response(404)
+                self.end_headers()
+            return False
+        if not self.credential_store.auth_required():
+            return True
+        authorization_header = self.headers.get("Authorization")
+        if self.auth_gate.is_authorized(authorization_header):
+            return True
+
+        if self.command in {"POST", "PUT", "PATCH"}:
+            self.discard_available_request_body()
+        self.close_connection = True
+        body = b"Authentication required.\n"
+        self.send_response(401)
+        self.send_header(
+            "WWW-Authenticate",
+            'Basic realm="Bjorn", charset="UTF-8"',
+        )
+        self.send_header("Content-Type", "text/plain; charset=utf-8")
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("Connection", "close")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        if send_body:
+            self.wfile.write(body)
+        if authorization_header:
+            request_path = self.path.partition("?")[0].partition("#")[0]
+            logger.warning(
+                "Rejected invalid web credentials for "
+                f"{self.command} {request_path} from {self.client_address[0]}"
+            )
+        return False
+
     def do_GET(self):
         # Handle GET requests. Serve the HTML interface and the EPD image.
+        if not self.require_authorization():
+            return
         if self.path == '/index.html' or self.path == '/':
             self.serve_file_gzipped(os.path.join(self.shared_data.webdir, 'index.html'), 'text/html')
         elif self.path == '/config.html':
@@ -117,6 +205,8 @@ class CustomHandler(http.server.SimpleHTTPRequestHandler):
 
     def do_POST(self):
         # Handle POST requests for saving configuration, connecting to Wi-Fi, clearing files, rebooting, and shutting down.
+        if not self.require_authorization():
+            return
         if self.path == '/save_config':
             self.web_utils.save_configuration(self)
         elif self.path == '/connect_wifi':
@@ -150,12 +240,17 @@ class CustomHandler(http.server.SimpleHTTPRequestHandler):
             self.send_response(404)
             self.end_headers()
 
+    def do_HEAD(self):
+        if not self.require_authorization(send_body=False):
+            return
+        super().do_HEAD()
+
 class WebThread(threading.Thread):
     """
     Thread to run the web server serving the EPD display interface.
     """
     def __init__(self, handler_class=CustomHandler, port=8000):
-        super().__init__()
+        super().__init__(name="BjornWeb")
         self.shared_data = shared_data
         self.port = port
         self.handler_class = handler_class
@@ -167,21 +262,32 @@ class WebThread(threading.Thread):
         """
         while not self.shared_data.webapp_should_exit:
             try:
-                with socketserver.TCPServer(("", self.port), self.handler_class) as httpd:
+                with ReusableTCPServer(("", self.port), self.handler_class) as httpd:
                     self.httpd = httpd
+                    httpd.timeout = 0.5
                     logger.info(f"Serving at port {self.port}")
                     while not self.shared_data.webapp_should_exit:
                         httpd.handle_request()
             except OSError as e:
+                if self.shared_data.webapp_should_exit:
+                    break
                 if e.errno == 98:  # Address already in use error
                     logger.warning(f"Port {self.port} is in use, trying the next port...")
                     self.port += 1
                 else:
                     logger.error(f"Error in web server: {e}")
                     break
+            except Exception as e:
+                if not self.shared_data.webapp_should_exit:
+                    logger.error(
+                        "Unexpected web server thread error "
+                        f"({type(e).__name__}): {e}"
+                    )
+                break
             finally:
                 if self.httpd:
                     self.httpd.server_close()
+                    self.httpd = None
                     logger.info("Web server closed.")
 
     def shutdown(self):

--- a/webapp.py
+++ b/webapp.py
@@ -41,13 +41,18 @@ class CustomHandler(http.server.SimpleHTTPRequestHandler):
         self.auth_gate = auth_gate
         super().__init__(*args, **kwargs)
 
+    def log_request(self, code='-', size='-'):
+        """Suppress routine read-only access logs."""
+        if self.command in {'GET', 'HEAD'}:
+            return
+        super().log_request(code, size)
+
     def log_message(self, format, *args):
-        # Override to suppress logging of GET requests.
-        if 'GET' not in format % args:
-            logger.info("%s - - [%s] %s\n" %
-                        (self.client_address[0],
-                         self.log_date_time_string(),
-                         format % args))
+        message = format % args
+        logger.info("%s - - [%s] %s" %
+                    (self.client_address[0],
+                     self.log_date_time_string(),
+                     message))
 
     def gzip_encode(self, content):
         """Gzip compress the given content."""


### PR DESCRIPTION
## Summary

This change bounds scanner concurrency, makes service and hardware shutdown
deterministic, and adds opt-in password protection to the complete Bjorn web
surface.

## Maintainer note: why this is one combined pull request

Hi, and thank you for maintaining Bjorn. I realize that this is a substantial
change set, spanning 31 files, so I want to explain the integration boundary
up front.

The two user-facing goals—runtime stability on resource-constrained Raspberry
Pi devices and optional web authentication—look separable conceptually, but
they are not independent at the implementation, deployment, and validation
boundaries:

- Both change `webapp.py`. The lifecycle work replaces the server loop,
  shutdown behavior, socket reuse, and request timing, while authentication
  wraps every GET, HEAD, POST, API, static-file, and error path. Maintaining
  separate versions would create overlapping and order-dependent patches to
  the same request handler.
- Both change installation and service startup. Authentication setup,
  credential permissions, port readiness, service restart, and rollback must
  operate against the exact web-server implementation being installed.
- Scanner resource exhaustion previously affected the availability and clean
  shutdown of the same web process. Bounded worker pools, shutdown-aware Nmap,
  and deterministic thread cleanup are therefore part of keeping the
  authenticated interface reliably reachable on a Pi Zero 2 W.
- The safety guarantees are end-to-end. The validation suite checks a real
  scan, bounded thread use, clean service stop/start, port reuse, every
  authenticated route, malformed requests, credential restoration, installer
  rollback, and reboot persistence against one exact runtime state.

The features could theoretically be split, but not as two independent
drop-in patches without introducing temporary compatibility layers, duplicated
installers, competing versions of shared files, order-dependent rollouts, and
a larger matrix of partially integrated states. That would make each pull
request appear smaller while moving the main risk into the untested boundary
between them.

For that reason, this contribution uses one transactional installer, one
rollback snapshot, and one combined validation entry point. Authentication
remains strictly opt-in; installations without a credential file retain the
existing open behavior.

Most of the size is verification and operational safety rather than additional
runtime behavior: 3,920 of 6,088 added lines are tests (about 64%). Tests,
documentation, and transactional installation/rollback tooling together
account for 5,008 added lines (about 82%).

## Scanner and lifecycle changes

- Replace unmanaged host and port threads with bounded worker pools.
- Wait for submitted workers before sorting, aggregating, or writing results.
- Consume worker results without materializing unused result lists while
  preserving worker exception propagation.
- Normalize semicolon-separated port data before live-status aggregation and
  stop the aggregation pipeline at the failing step without logging false
  success.
- Deduplicate configured ports and close sockets deterministically.
- Keep the Python main thread alive while Bjorn's primary thread runs.
- Run the existing Nmap discovery command as a shutdown-aware child process
  and parse completed XML through the installed `python-nmap` library.
- Disable Rich's background refresh worker and update progress synchronously.
- Make the web socket reusable, bound request waits, name the web thread, and
  handle its shutdown explicitly.
- Replace display sleeps with interruptible waits.
- Put the e-paper panel to sleep and close gpiozero devices, the shared pin
  factory, and lgpio's module-global notification worker.
- Report residual Python threads and fail shutdown explicitly when a worker
  misses its bounded deadline.

## Optional web authentication

- Add a credential store using salted scrypt password verifiers.
- Add `http_auth` management commands for `set`, `status`, `enable`, and
  `disable`; interactive setup keeps plaintext passwords out of arguments and
  shell history.
- Protect every GET, HEAD, POST, API, static, and file route when enabled.
- Return a standards-compatible `401` challenge.
- Suppress routine GET and HEAD access logs while retaining POST and genuine
  error diagnostics.
- Keep normal headerless browser challenges out of the warning log while
  retaining audit warnings for malformed or incorrect credentials.
- Reject incomplete unauthenticated entity-bearing requests without waiting
  for unsent body bytes.
- Prevent `config/web_auth.json` from being served as static content.
- Fail closed for an existing unreadable or malformed credential file.
- Cache only a SHA-256 digest of a successful Authorization header for 30
  seconds and invalidate it when credential contents, mode, owner, or group
  change.
- Preserve current open behavior when no credential file exists.

## Deployment and rollback

`install_stability_web_auth.sh` validates the complete source set, creates one
snapshot, stops `bjorn.service` once, installs the exact tested files, verifies
Python compilation, restarts the service, and accepts only a healthy HTTP 200
or 401 response on port 8000.

Any validation, installation, or startup failure restores the entire previous
state. Explicit `--restore` also creates a recovery snapshot before applying
the selected rollback. The normal fresh installer asks whether the optional
global `/usr/local/sbin/http_auth` management command should be installed and,
independently, whether credentials should be configured immediately.
Credential validation failures repeat the credential prompt without advancing
to ownership changes, while failures in required installer steps abort instead
of presenting a retry option that cannot replay the failed command. Fresh
installation starts the service and reports success only when the unit is
active and port 8000 returns HTTP 200 or 401.

## Backwards compatibility

- Authentication is opt-in.
- No configuration keys or output formats change.
- Normal Nmap discovery is not shortened.
- Scan-result cleanup and retention behavior are unchanged.
- No new runtime dependency is introduced for authentication.

## Automated validation

```bash
./tests/run_stability_web_auth_validation.sh --unit

sudo ./tests/run_stability_web_auth_validation.sh --all \
  --target /home/bjorn/Bjorn \
  --duration 30

git diff --check

sudo ./tests/run_reboot_persistence_validation.sh --prepare
sudo reboot
sudo ./tests/run_reboot_persistence_validation.sh --verify
```

The combined checkout currently has 64 unique unit and integration tests
covering scanner completion, worker limits, Nmap shutdown, process lifecycle,
display/GPIO cleanup, installer recovery ordering and port readiness,
credential parsing, configuration commands, every known web route, audit
behavior, incomplete POST handling, port reuse, web-thread shutdown, and the
isolated fresh-installer decline/install/configure/manage workflow. Dedicated
regressions also verify that manual web-server shutdown never calls the
`serve_forever()`-only shutdown primitive, fatal installer validation cannot be
swallowed by a conditional Bash function, and credential access-metadata
changes invalidate cached authorization.

## Raspberry Pi Zero 2 W validation

- Complete scans finished without executor, thread-creation, pandas, or
  live-status aggregation errors.
- Live thread use peaked at 47 and returned to the 15-thread idle baseline.
- Repeated clean service stops completed in 4 to 15 seconds and restarted on
  port 8000.
- Live authentication command, route, challenge-stress, malformed-request, and
  credential-restoration checks passed.
- The isolated fresh-installer flow passed on Raspberry Pi OS: declining the
  optional tool left no command behind; accepting it created a real symbolic
  link; credential setup, status, disable, enable, and password verification
  passed; and the credential file mode was exactly `0600`.
- A second physical clean-card install started from a verified empty target on
  Raspberry Pi OS Lite 64-bit. Three deliberately invalid short-password
  attempts each returned to the credential prompt. A valid fourth attempt
  created the mode-`0600` credential file, started `bjorn.service`, returned
  HTTP 401 on port 8000, and completed without any false-success warning.
- The final post-review combined suite on that clean installation ran 64 tests
  in 10.483 seconds, completed a live scan, peaked at 47 threads, stopped
  cleanly in 7 seconds, restarted on port 8000, exercised 30 browser
  challenges, and restored the original credential state.
- A real reboot changed the kernel boot ID, auto-started `bjorn.service`,
  preserved HTTP 401 access control, completed a scan, and remained at or below
  47 threads.
- The clean-card reboot validation observed the first completed scan after 35
  seconds with PID 363, a 15-thread idle state, a 47-thread peak, unchanged
  credential hash and management-command target, and no current-boot runtime
  errors.
- No Python-finalization, scanner, or lifecycle errors remained in the
  validated current-boot journal.

Tested with Debian 12 Bookworm arm64, Python 3.11, `python-nmap` 0.7.1, and a
Waveshare 2.13-inch V4 display.